### PR TITLE
Changed style of `Mark` from `TabHome` and `OK` from `InfoModal` buttons

### DIFF
--- a/src/modals/InfoModal.css
+++ b/src/modals/InfoModal.css
@@ -43,10 +43,7 @@ ion-button.ok-modal {
     width: 30%;
     height: 10%;
 
-    --background: var(--ion-color-opposite);
     --border-radius: 20px;
-    --box-shadow: none;
-    --color: var(--ion-color-dark-basic);
 
     transform: translateX(-40%);
 }

--- a/src/modals/InfoModal.css
+++ b/src/modals/InfoModal.css
@@ -52,6 +52,5 @@ ion-button.ok-modal {
 }
 
 ion-button.ok-modal:hover {
-    border: 2px var(--ion-color-dark-basic) solid;
     border-radius: 20px;
 }

--- a/src/modals/InfoModal.css
+++ b/src/modals/InfoModal.css
@@ -50,7 +50,3 @@ ion-button.ok-modal {
 
     transform: translateX(-40%);
 }
-
-ion-button.ok-modal:hover {
-    border-radius: 20px;
-}

--- a/src/modals/InfoModal.tsx
+++ b/src/modals/InfoModal.tsx
@@ -92,6 +92,7 @@ const InfoModal = (props: PropsInfoModal) => {
                 <div id="small-rectangle"></div>
                 <IonButton
                     class="ok-modal"
+                    color="dark-basic"
                     onClick={() => props.setIsOpen(false)}>
                     Ok
                 </IonButton>

--- a/src/pages/TabHome.css
+++ b/src/pages/TabHome.css
@@ -22,7 +22,6 @@ ion-button {
 }
 
 .mark-button:hover {
-    border: 2px var(--ion-color-dark-basic) solid;
     border-radius: 10px;
 }
 

--- a/src/pages/TabHome.css
+++ b/src/pages/TabHome.css
@@ -21,10 +21,6 @@ ion-button {
     --background: var(--ion-color-opposite);
 }
 
-.mark-button:hover {
-    border-radius: 10px;
-}
-
 .info-button {
     font-size: 10px;
 

--- a/src/pages/TabHome.css
+++ b/src/pages/TabHome.css
@@ -17,8 +17,6 @@ ion-button {
 
 .mark-button {
     --border-radius: 10px;
-    --color: var(--ion-color-dark-basic);
-    --background: var(--ion-color-opposite);
 }
 
 .info-button {

--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -109,9 +109,12 @@ const MarkPeriodLabel = () => {
       <IonLabel style={{ textAlign: "center" }} color="dark-basic">
         <h1 style={{ fontWeight: "bold" }}>{daysBeforePeriod.days}</h1>
       </IonLabel>
-      <IonButton class="mark-button" onClick={() => {
-        setIsMarkModal(true);
-      }}
+      <IonButton
+        class="mark-button"
+        color="dark-basic"
+        onClick={() => {
+          setIsMarkModal(true);
+        }}
       >
         Mark</IonButton>
       <MarkModal


### PR DESCRIPTION
Closed #45 

In this PR styles for `Mark` button from `TabHome.tsx` and `OK` button from `InfoModal` was changed

Also I removed solid border around these buttons because previously there was border duplication, as examples:

![Screenshot from 2023-06-12 22-50-51](https://github.com/IraSoro/peri/assets/28269602/da679b38-cd4c-4985-99a3-a11f5eeec08d)

![Screenshot from 2023-06-12 22-50-19](https://github.com/IraSoro/peri/assets/28269602/f39a341f-baa4-49c5-8fe2-c9c0667d94d8)

