### PR TITLE
Error when marking a new cycle

### DIFF
--- a/src/state/CycleInformationHooks.tsx
+++ b/src/state/CycleInformationHooks.tsx
@@ -1,6 +1,8 @@
 import { useContext } from 'react';
 import { CyclesContext } from './Context';
 
+const millisecondsInDay = 24 * 60 * 60 * 1000;
+
 export function useLastStartDate(): string {
     const cycles = useContext(CyclesContext).cycles;
 
@@ -19,9 +21,11 @@ export function useDayOfCycle(): string {
     }
 
     const start = new Date(startDate);
+    start.setHours(0, 0, 0, 0);
     const currentDate = new Date();
+    currentDate.setHours(0, 0, 0, 0);
 
-    const diff = currentDate.getDay() - start.getDay() + 1;
+    const diff = Math.ceil((currentDate.getTime() - start.getTime()) / millisecondsInDay) + 1;
 
     return diff.toString();
 }

--- a/src/state/CycleInformationHooks.tsx
+++ b/src/state/CycleInformationHooks.tsx
@@ -1,8 +1,6 @@
 import { useContext } from 'react';
 import { CyclesContext } from './Context';
 
-const millisecondsInDay = 24 * 60 * 60 * 1000;
-
 export function useLastStartDate(): string {
     const cycles = useContext(CyclesContext).cycles;
 
@@ -23,9 +21,9 @@ export function useDayOfCycle(): string {
     const start = new Date(startDate);
     const currentDate = new Date();
 
-    const diff = new Date(currentDate.getTime() - start.getTime());
+    const diff = currentDate.getDay() - start.getDay() + 1;
 
-    return Math.ceil(diff.getTime() / millisecondsInDay).toString();
+    return diff.toString();
 }
 
 export function useAverageLengthOfCycle(): number {


### PR DESCRIPTION
Closed #57 

When the current date is set, the time is set with a time zone offset. Therefore, there is a possibility that the current date will be greater than the start date. There was also a bad idea for such a conversion: 
```const diff = new Date(currentDate.getTime() - start.getTime());```
So now I count the difference in days. And I'm adding 1 because the loop includes the current date.
```const diff = currentDate.getDay() - start.getDay() + 1;```