### PR TITLE
Edit Mark Modal UI

### DIFF
--- a/src/modals/MarkModal.css
+++ b/src/modals/MarkModal.css
@@ -1,7 +1,11 @@
-.mark-modal {
-  --width: fit-content;
-  --min-width: 250px;
-  --height: fit-content;
-  --border-radius: 16px;
-  --box-shadow: 0 28px 48px rgba(0, 0, 0, 0.4);
+ion-datetime.mark-modal {
+  border-radius: 16px;
+  border: 2px var(--ion-color-light) solid;
 }
+
+ion-button.save-buttons {
+  width: 110px;
+  float: right;
+  --border-radius: 10px;
+}
+

--- a/src/modals/MarkModal.css
+++ b/src/modals/MarkModal.css
@@ -8,4 +8,3 @@ ion-button.save-buttons {
   float: right;
   --border-radius: 10px;
 }
-

--- a/src/modals/MarkModal.tsx
+++ b/src/modals/MarkModal.tsx
@@ -25,12 +25,7 @@ interface PropsMarkModal {
 const MarkModal = (props: PropsMarkModal) => {
   const { t } = useTranslation();
   const datetimeRef = useRef<null | HTMLIonDatetimeElement>(null);
-
   const { cycles, updateCycles } = useContext(CyclesContext);
-
-  const isActiveDates = (date: string) => {
-    return getMarkModalActiveDates(date, cycles);
-  };
 
   return (
     <>
@@ -67,7 +62,9 @@ const MarkModal = (props: PropsMarkModal) => {
             size="cover"
             multiple
             firstDayOfWeek={1}
-            isDateEnabled={isActiveDates}
+            isDateEnabled={(date: string) => {
+              return getMarkModalActiveDates(date, cycles);
+            }}
             value={getPastFuturePeriodDays(cycles)}
           />
           <IonItem

--- a/src/modals/MarkModal.tsx
+++ b/src/modals/MarkModal.tsx
@@ -11,9 +11,8 @@ import { useTranslation } from "react-i18next";
 import "./MarkModal.css";
 
 import { CyclesContext } from "../state/Context";
-import { useAverageLengthOfPeriod } from "../state/CycleInformationHooks";
 import {
-  getMarkActiveDates,
+  getMarkModalActiveDates,
   getPastFuturePeriodDays,
   getNewCyclesHistory,
 } from "../state/CalculationLogics";
@@ -28,10 +27,9 @@ const MarkModal = (props: PropsMarkModal) => {
   const datetimeRef = useRef<null | HTMLIonDatetimeElement>(null);
 
   const { cycles, updateCycles } = useContext(CyclesContext);
-  const lengthOfPeriod = useAverageLengthOfPeriod();
 
   const isActiveDates = (date: string) => {
-    return getMarkActiveDates(date, cycles);
+    return getMarkModalActiveDates(date, cycles);
   };
 
   return (
@@ -70,7 +68,7 @@ const MarkModal = (props: PropsMarkModal) => {
             multiple
             firstDayOfWeek={1}
             isDateEnabled={isActiveDates}
-            value={getPastFuturePeriodDays(cycles, lengthOfPeriod)}
+            value={getPastFuturePeriodDays(cycles)}
           />
           <IonItem
             color="basic"

--- a/src/modals/MarkModal.tsx
+++ b/src/modals/MarkModal.tsx
@@ -7,12 +7,16 @@ import {
   IonItem,
   IonLabel,
 } from "@ionic/react";
-import { format } from "date-fns";
 import { useTranslation } from "react-i18next";
 import "./MarkModal.css";
 
 import { CyclesContext } from "../state/Context";
 import { useAverageLengthOfPeriod } from "../state/CycleInformationHooks";
+import {
+  getMarkActiveDates,
+  getPastFuturePeriodDays,
+  getNewCyclesHistory,
+} from "../state/CalculationLogics";
 
 interface PropsMarkModal {
   isOpen: boolean;
@@ -26,62 +30,8 @@ const MarkModal = (props: PropsMarkModal) => {
   const { cycles, updateCycles } = useContext(CyclesContext);
   const lengthOfPeriod = useAverageLengthOfPeriod();
 
-  const nowDate = new Date();
-  nowDate.setHours(0, 0, 0, 0);
-
-  const nextCycleFinish: Date = new Date();
-  nextCycleFinish.setDate(nowDate.getDate() + lengthOfPeriod);
-  nextCycleFinish.setHours(0, 0, 0, 0);
-
-  function isPastPeriodDay(date: Date) {
-    date.setHours(0, 0, 0, 0);
-
-    return cycles.some((cycle) => {
-      const startOfCycle = new Date(cycle.startDate);
-      startOfCycle.setHours(0, 0, 0, 0);
-      const endOfCycle = new Date(cycle.startDate);
-      endOfCycle.setHours(0, 0, 0, 0);
-      endOfCycle.setDate(endOfCycle.getDate() + cycle.periodLength);
-      return date >= startOfCycle && date < endOfCycle;
-    });
-  }
-
-  function nextPeriodDays() {
-    const periodDates: string[] = [];
-    if (cycles.length !== 0) {
-      const endOfCurrentCycle = new Date(cycles[0].startDate);
-      endOfCurrentCycle.setDate(
-        endOfCurrentCycle.getDate() + cycles[0].periodLength,
-      );
-      endOfCurrentCycle.setHours(0, 0, 0, 0);
-      if (endOfCurrentCycle >= nowDate) {
-        return undefined;
-      }
-    }
-
-    for (let day = 0; day < (lengthOfPeriod || 5); day++) {
-      const periodDay = new Date(nowDate);
-      periodDay.setHours(0, 0, 0, 0);
-      periodDay.setDate(periodDay.getDate() + day);
-
-      periodDates.push(format(periodDay, "yyyy-MM-dd"));
-    }
-
-    return periodDates;
-  }
-
-  const isActiveDates = (dateString: string) => {
-    if (cycles.length === 0) {
-      return true;
-    }
-    const date = new Date(dateString);
-    date.setHours(0, 0, 0, 0);
-
-    const lastCycleFinish: Date = new Date(cycles[0].startDate);
-    lastCycleFinish.setDate(lastCycleFinish.getDate() + cycles[0].periodLength);
-    lastCycleFinish.setHours(0, 0, 0, 0);
-
-    return date.getTime() > lastCycleFinish.getTime();
+  const isActiveDates = (date: string) => {
+    return getMarkActiveDates(date, cycles);
   };
 
   return (
@@ -120,22 +70,7 @@ const MarkModal = (props: PropsMarkModal) => {
             multiple
             firstDayOfWeek={1}
             isDateEnabled={isActiveDates}
-            value={nextPeriodDays()}
-            highlightedDates={(isoString) => {
-              if (cycles.length === 0) {
-                return undefined;
-              }
-
-              const date = new Date(isoString);
-              if (isPastPeriodDay(date)) {
-                return {
-                  textColor: "var(--ion-color-light)",
-                  backgroundColor: "var(--ion-color-basic)",
-                };
-              }
-
-              return undefined;
-            }}
+            value={getPastFuturePeriodDays(cycles, lengthOfPeriod)}
           />
           <IonItem
             color="basic"
@@ -147,44 +82,13 @@ const MarkModal = (props: PropsMarkModal) => {
             fill="solid"
             onClick={() => {
               if (datetimeRef.current?.value) {
-                const markPeriodDays = [datetimeRef.current.value]
-                  .flat()
-                  .sort();
-                if (cycles.length > 0) {
-                  const millisecondsInDay = 24 * 60 * 60 * 1000;
-
-                  const startDate = new Date(cycles[0].startDate);
-                  const finishDate = new Date(markPeriodDays[0]);
-
-                  const diff = new Date(
-                    finishDate.getTime() - startDate.getTime(),
-                  );
-                  cycles[0].cycleLength =
-                    Math.ceil(diff.getTime() / millisecondsInDay) - 1;
-
-                  cycles.unshift({
-                    cycleLength: 0,
-                    periodLength: markPeriodDays.length,
-                    startDate: markPeriodDays[0],
-                  });
-                } else {
-                  cycles.unshift({
-                    cycleLength: 28,
-                    periodLength: markPeriodDays.length,
-                    startDate: markPeriodDays[0],
-                  });
-                }
+                const newCycles = getNewCyclesHistory(
+                  [datetimeRef.current.value].flat(),
+                );
+                updateCycles(newCycles);
               }
-
-              Promise.all([updateCycles([...cycles])])
-                .then(() => {
-                  console.log("All new values are set, setIsOpen(false)");
-                  datetimeRef.current
-                    ?.confirm()
-                    .catch((err) => console.error(err));
-                  props.setIsOpen(false);
-                })
-                .catch((err) => console.error(err));
+              datetimeRef.current?.confirm().catch((err) => console.error(err));
+              props.setIsOpen(false);
             }}
           >
             {t("save")}

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -311,7 +311,7 @@ export function getActiveDates(
 
 // For Mark Modal
 
-export function getMarkActiveDates(dateString: string, cycles: Cycle[]) {
+export function getMarkModalActiveDates(dateString: string, cycles: Cycle[]) {
   if (cycles.length === 0) {
     return true;
   }
@@ -328,14 +328,12 @@ export function getMarkActiveDates(dateString: string, cycles: Cycle[]) {
   return date.getTime() > futureCycleFinish.getTime();
 }
 
-export function getPastFuturePeriodDays(
-  cycles: Cycle[],
-  lengthOfPeriod: number,
-) {
+export function getPastFuturePeriodDays(cycles: Cycle[]) {
   const nowDate = new Date();
   nowDate.setHours(0, 0, 0, 0);
 
-  const periodDates: string[] = getLastPeriodDays(cycles);
+  const periodDates = getLastPeriodDays(cycles);
+  const lengthOfPeriod = getAverageLengthOfPeriod(cycles);
 
   if (cycles.length !== 0) {
     const endOfCurrentCycle = new Date(cycles[0].startDate);

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -308,3 +308,63 @@ export function getActiveDates(
     date.getTime() <= nowDate.getTime()
   );
 }
+
+// For Mark Modal
+
+export function getMarkActiveDates(dateString: string, cycles: Cycle[]) {
+  if (cycles.length === 0) {
+    return true;
+  }
+
+  const date = new Date(dateString);
+  date.setHours(0, 0, 0, 0);
+
+  const futureCycleFinish: Date = new Date(cycles[0].startDate);
+  futureCycleFinish.setDate(
+    futureCycleFinish.getDate() + cycles[0].periodLength,
+  );
+  futureCycleFinish.setHours(0, 0, 0, 0);
+
+  return date.getTime() > futureCycleFinish.getTime();
+}
+
+export function getIsPastPeriodDay(date: Date, cycles: Cycle[]) {
+  date.setHours(0, 0, 0, 0);
+
+  return cycles.some((cycle) => {
+    const startOfCycle = new Date(cycle.startDate);
+    startOfCycle.setHours(0, 0, 0, 0);
+    const endOfCycle = new Date(cycle.startDate);
+    endOfCycle.setHours(0, 0, 0, 0);
+    endOfCycle.setDate(endOfCycle.getDate() + cycle.periodLength);
+    return date >= startOfCycle && date < endOfCycle;
+  });
+}
+
+export function getNextPeriodDays(cycles: Cycle[], lengthOfPeriod: number) {
+  const nowDate = new Date();
+  nowDate.setHours(0, 0, 0, 0);
+
+  const periodDates: string[] = [];
+
+  if (cycles.length !== 0) {
+    const endOfCurrentCycle = new Date(cycles[0].startDate);
+    endOfCurrentCycle.setDate(
+      endOfCurrentCycle.getDate() + cycles[0].periodLength,
+    );
+    endOfCurrentCycle.setHours(0, 0, 0, 0);
+    if (endOfCurrentCycle >= nowDate) {
+      return undefined;
+    }
+  }
+
+  for (let day = 0; day < (lengthOfPeriod || 5); day++) {
+    const periodDay = new Date(nowDate);
+    periodDay.setHours(0, 0, 0, 0);
+    periodDay.setDate(periodDay.getDate() + day);
+
+    periodDates.push(format(periodDay, "yyyy-MM-dd"));
+  }
+
+  return periodDates;
+}

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -328,24 +328,14 @@ export function getMarkActiveDates(dateString: string, cycles: Cycle[]) {
   return date.getTime() > futureCycleFinish.getTime();
 }
 
-export function getIsPastPeriodDay(date: Date, cycles: Cycle[]) {
-  date.setHours(0, 0, 0, 0);
-
-  return cycles.some((cycle) => {
-    const startOfCycle = new Date(cycle.startDate);
-    startOfCycle.setHours(0, 0, 0, 0);
-    const endOfCycle = new Date(cycle.startDate);
-    endOfCycle.setHours(0, 0, 0, 0);
-    endOfCycle.setDate(endOfCycle.getDate() + cycle.periodLength);
-    return date >= startOfCycle && date < endOfCycle;
-  });
-}
-
-export function getNextPeriodDays(cycles: Cycle[], lengthOfPeriod: number) {
+export function getPastFuturePeriodDays(
+  cycles: Cycle[],
+  lengthOfPeriod: number,
+) {
   const nowDate = new Date();
   nowDate.setHours(0, 0, 0, 0);
 
-  const periodDates: string[] = [];
+  const periodDates: string[] = getLastPeriodDays(cycles);
 
   if (cycles.length !== 0) {
     const endOfCurrentCycle = new Date(cycles[0].startDate);

--- a/src/tests/CalculationLogic.test.ts
+++ b/src/tests/CalculationLogic.test.ts
@@ -12,6 +12,8 @@ import {
   getNewCyclesHistory,
   getActiveDates,
   getLastPeriodDays,
+  getMarkModalActiveDates,
+  getPastFuturePeriodDays,
 } from "../state/CalculationLogics";
 
 describe("getOvulationStatus", () => {
@@ -585,5 +587,155 @@ describe("getActiveDates", () => {
     expect(getActiveDates(format(dateCheck, "yyyy-MM-dd"), cycles, 28)).toEqual(
       false,
     );
+  });
+});
+
+describe("getMarkModalActiveDates", () => {
+  test("cycles array is empty", () => {
+    // @ts-expect-error mocked `t` method
+    jest.spyOn(i18n, "t").mockImplementation((key) => key);
+    expect(getMarkModalActiveDates("", [])).toEqual(true);
+  });
+
+  test("cycles array has a few items and date is less than the finish of the last cycle", () => {
+    // @ts-expect-error mocked `t` method
+    jest.spyOn(i18n, "t").mockImplementation((key) => key);
+
+    const date: Date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + 20);
+
+    const cycles: Cycle[] = [];
+
+    for (let i = 0; i < 6; ++i) {
+      date.setDate(date.getDate() - 28);
+      cycles.push({
+        cycleLength: 28,
+        periodLength: 6,
+        startDate: date.toString(),
+      });
+    }
+
+    const dateCheck = new Date(cycles[0].startDate);
+    dateCheck.setDate(dateCheck.getDate() + 5);
+
+    expect(
+      getMarkModalActiveDates(format(dateCheck, "yyyy-MM-dd"), cycles),
+    ).toEqual(false);
+  });
+
+  test("cycles array has a few items and date is more than the finish of the last cycle", () => {
+    // @ts-expect-error mocked `t` method
+    jest.spyOn(i18n, "t").mockImplementation((key) => key);
+
+    const date: Date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + 20);
+
+    const cycles: Cycle[] = [];
+
+    for (let i = 0; i < 6; ++i) {
+      date.setDate(date.getDate() - 28);
+      cycles.push({
+        cycleLength: 28,
+        periodLength: 6,
+        startDate: date.toString(),
+      });
+    }
+
+    const dateCheck = new Date(cycles[0].startDate);
+    dateCheck.setDate(dateCheck.getDate() + 40);
+
+    expect(
+      getMarkModalActiveDates(format(dateCheck, "yyyy-MM-dd"), cycles),
+    ).toEqual(true);
+  });
+});
+
+describe("getPastFuturePeriodDays", () => {
+  test("cycles array is empty", () => {
+    // @ts-expect-error mocked `t` method
+    jest.spyOn(i18n, "t").mockImplementation((key) => key);
+
+    const periodDates: string[] = [];
+    const nowDate = new Date();
+    nowDate.setHours(0, 0, 0, 0);
+
+    for (let day = 0; day < 5; day++) {
+      const periodDay = new Date(nowDate);
+      periodDay.setHours(0, 0, 0, 0);
+      periodDay.setDate(periodDay.getDate() + day);
+
+      periodDates.push(format(periodDay, "yyyy-MM-dd"));
+    }
+    expect(getPastFuturePeriodDays([])).toEqual(periodDates);
+  });
+
+  test("cycles array has a few items", () => {
+    // @ts-expect-error mocked `t` method
+    jest.spyOn(i18n, "t").mockImplementation((key) => key);
+
+    const date: Date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() + 10);
+
+    const cycles: Cycle[] = [];
+
+    for (let i = 0; i < 6; ++i) {
+      date.setDate(date.getDate() - 28);
+      cycles.push({
+        cycleLength: 28,
+        periodLength: 5,
+        startDate: date.toString(),
+      });
+    }
+
+    const periodDates = getLastPeriodDays(cycles);
+    const nowDate = new Date();
+    nowDate.setHours(0, 0, 0, 0);
+
+    for (let day = 0; day < 5; day++) {
+      const periodDay = new Date(nowDate);
+      periodDay.setHours(0, 0, 0, 0);
+      periodDay.setDate(periodDay.getDate() + day);
+
+      periodDates.push(format(periodDay, "yyyy-MM-dd"));
+    }
+
+    expect(getPastFuturePeriodDays(cycles)).toEqual(periodDates);
+  });
+
+  test("delay a few days", () => {
+    // @ts-expect-error mocked `t` method
+    jest.spyOn(i18n, "t").mockImplementation((key) => key);
+
+    const date: Date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() - 5);
+
+    const cycles: Cycle[] = [];
+
+    for (let i = 0; i < 6; ++i) {
+      date.setDate(date.getDate() - 28);
+      cycles.push({
+        cycleLength: 28,
+        periodLength: 5,
+        startDate: date.toString(),
+      });
+    }
+
+    const periodDates = getLastPeriodDays(cycles);
+    const nowDate = new Date();
+    nowDate.setHours(0, 0, 0, 0);
+
+    for (let day = 0; day < 5; day++) {
+      const periodDay = new Date(nowDate);
+      periodDay.setHours(0, 0, 0, 0);
+      periodDay.setDate(periodDay.getDate() + day);
+
+      periodDates.push(format(periodDay, "yyyy-MM-dd"));
+    }
+
+    expect(getPastFuturePeriodDays(cycles)).toEqual(periodDates);
   });
 });

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -99,6 +99,13 @@ http://ionicframework.com/docs/theming/ */
   --ion-color-white-basic-shade: #a9a0d5;
   --ion-color-white-basic-tint: #c6bdf3;
 
+  --ion-color-light-basic: #B6ACE7;
+  --ion-color-light-basic-rgb: 182,172,231;
+  --ion-color-light-basic-contrast: #000000;
+  --ion-color-light-basic-contrast-rgb: 0,0,0;
+  --ion-color-light-basic-shade: #a097cb;
+  --ion-color-light-basic-tint: #bdb4e9;
+
   --ion-color-opposite: #fffdb7;
   --ion-color-opposite-rgb: 255, 253, 183;
   --ion-color-opposite-contrast: #000000;
@@ -130,6 +137,15 @@ http://ionicframework.com/docs/theming/ */
   --ion-color-contrast-rgb: var(--ion-color-white-basic-contrast-rgb);
   --ion-color-shade: var(--ion-color-white-basic-shade);
   --ion-color-tint: var(--ion-color-white-basic-tint);
+}
+
+.ion-color-light-basic {
+  --ion-color-base: var(--ion-color-light-basic);
+  --ion-color-base-rgb: var(--ion-color-light-basic-rgb);
+  --ion-color-contrast: var(--ion-color-light-basic-contrast);
+  --ion-color-contrast-rgb: var(--ion-color-light-basic-contrast-rgb);
+  --ion-color-shade: var(--ion-color-light-basic-shade);
+  --ion-color-tint: var(--ion-color-light-basic-tint);
 }
 
 .ion-color-opposite {

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -99,12 +99,12 @@ http://ionicframework.com/docs/theming/ */
   --ion-color-white-basic-shade: #a9a0d5;
   --ion-color-white-basic-tint: #c6bdf3;
 
-  --ion-color-light-basic: #B6ACE7;
-  --ion-color-light-basic-rgb: 182,172,231;
-  --ion-color-light-basic-contrast: #000000;
+  --ion-color-light-basic: #CCC5FE;
+  --ion-color-light-basic-rgb: 204,197,254;
+  --ion-color-light-basic-contrast: #3B2D7C;
   --ion-color-light-basic-contrast-rgb: 0,0,0;
-  --ion-color-light-basic-shade: #a097cb;
-  --ion-color-light-basic-tint: #bdb4e9;
+  --ion-color-light-basic-shade: #b4ade0;
+  --ion-color-light-basic-tint: #d1cbfe;
 
   --ion-color-opposite: #fffdb7;
   --ion-color-opposite-rgb: 255, 253, 183;

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -99,10 +99,10 @@ http://ionicframework.com/docs/theming/ */
   --ion-color-white-basic-shade: #a9a0d5;
   --ion-color-white-basic-tint: #c6bdf3;
 
-  --ion-color-light-basic: #CCC5FE;
-  --ion-color-light-basic-rgb: 204,197,254;
-  --ion-color-light-basic-contrast: #3B2D7C;
-  --ion-color-light-basic-contrast-rgb: 0,0,0;
+  --ion-color-light-basic: #ccc5fe;
+  --ion-color-light-basic-rgb: 204, 197, 254;
+  --ion-color-light-basic-contrast: #3b2d7c;
+  --ion-color-light-basic-contrast-rgb: 0, 0, 0;
   --ion-color-light-basic-shade: #b4ade0;
   --ion-color-light-basic-tint: #d1cbfe;
 

--- a/src/translations/ru.tsx
+++ b/src/translations/ru.tsx
@@ -28,7 +28,7 @@ const ru = {
   date: "дата",
   // Mark Modal
   mark: "отметить",
-  "select date range": "отметьте диапазон месячных",
+  "Select date range": "Отметьте диапазон месячных",
   cancel: "отмена",
   save: "сохранить",
   // Welcome Modal


### PR DESCRIPTION
Closed #94

I changed the ui. Now it looks like this
![image](https://github.com/IraSoro/peri/assets/52165881/a7873824-8b9e-4044-a328-1eea1604189b)

I also moved all calculations to the ```CalculationLogics.ts```.  
I created ```getPastFuturePeriodDays``` function.  In the ```Mark Modal```, in the ```value``` property, I need to transfer all the past period days and the marked current ones. I already have a function for calculating past days - ```getLastPeriodDays```. But for the ```Mark Modal```, I also need to pass the estimated values of the marked periods. That's why I created the ```getPastFuturePeriodDays``` function. In it, I first call a ```getLastPeriodDays``` function to pass the days of the past period, and then I count the current ones.

Now I also updated storage using ```getNewCyclesHistory```. It is past function.

I created a new function to set active dates specifically for ```Mark Modal``` - ```getMarkModalActiveDates```. However, there is already a similar ```getActiveDates``` function but with an additional condition. I don't know how to fix it.