### PR TITLE
Add peri version displayed in menu

### DIFF
--- a/src/data/AppVersion.ts
+++ b/src/data/AppVersion.ts
@@ -1,0 +1,1 @@
+export const appVersion = "2.2.1";

--- a/src/modals/Menu.tsx
+++ b/src/modals/Menu.tsx
@@ -246,16 +246,6 @@ interface MenuProps {
   setIsEditModal: (newIsOpen: boolean) => void;
 }
 
-export const PeriAppVersion = () => {
-  return (
-    <IonItem>
-      <IonLabel color="medium">
-        The Period Tracker App Peri v{appVersion}
-      </IonLabel>
-    </IonItem>
-  );
-};
-
 export const Menu = (props: MenuProps) => {
   const { t } = useTranslation();
 
@@ -279,7 +269,11 @@ export const Menu = (props: MenuProps) => {
           setIsOpen={props.setIsEditModal}
         />
       </IonList>
-      <PeriAppVersion />
+      <IonItem>
+        <IonLabel color="medium">
+          The Period Tracker App Peri v{appVersion}
+        </IonLabel>
+      </IonItem>
     </IonMenu>
   );
 };

--- a/src/modals/Menu.tsx
+++ b/src/modals/Menu.tsx
@@ -22,6 +22,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { storage } from "../data/Storage";
 import { exportConfig, importConfig } from "../data/Config";
+import { appVersion } from "../data/AppVersion";
 import { CyclesContext } from "../state/Context";
 import { useAverageLengthOfCycle } from "../state/CycleInformationHooks";
 import {
@@ -245,6 +246,16 @@ interface MenuProps {
   setIsEditModal: (newIsOpen: boolean) => void;
 }
 
+export const PeriAppVersion = () => {
+  return (
+    <IonItem>
+      <IonLabel color="medium">
+        The Period Tracker App Peri v{appVersion}
+      </IonLabel>
+    </IonItem>
+  );
+};
+
 export const Menu = (props: MenuProps) => {
   const { t } = useTranslation();
 
@@ -268,6 +279,7 @@ export const Menu = (props: MenuProps) => {
           setIsOpen={props.setIsEditModal}
         />
       </IonList>
+      <PeriAppVersion />
     </IonMenu>
   );
 };


### PR DESCRIPTION
Closed #103 

I tried the following instruction to set env variables from `.env` file https://create-react-app.dev/docs/adding-custom-environment-variables/ and this works for web version, but doesn't for native android version

I read here https://github.com/ionic-team/ionic-cli/issues/4333 that this issue should be fixed with `.env.production` file or with `REACT_APP_APP_VERSION` env variable set before `ionic cap build android`, but it doesn't work

So, I decided to add file where we can set string with current version number. This solution works fine in both native and web versions

Now you should update `package.json` version and set the same version in `AppVersion.ts` file

Examples of app version displayed in menu:
![image](https://github.com/IraSoro/peri/assets/28269602/30804031-fc16-4ccf-9b6a-206d99ba56b2)
![image](https://github.com/IraSoro/peri/assets/28269602/73f8bfdf-67a5-4ac0-b075-c99acd55fb4b)