### PR TITLE
Fix progress bar display

### DIFF
--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -103,7 +103,7 @@ const CurrentCycle = () => {
   })}`;
 
   const startDate = new Date(getLastStartDate(cycles));
-  const averLengthOfPeriod = getAverageLengthOfPeriod(cycles);
+  const lengthOfPeriod = cycles[0].periodLength ?? 0;
   const averLengthOfCycle = getAverageLengthOfCycle(cycles);
 
   return (
@@ -116,7 +116,7 @@ const CurrentCycle = () => {
           class="current-progress"
           style={progressBarStyle}
           value={setValueProgress(
-            averLengthOfPeriod > dayOfCycle ? dayOfCycle : averLengthOfPeriod,
+            lengthOfPeriod > dayOfCycle ? dayOfCycle : lengthOfPeriod,
             averLengthOfCycle,
           )}
           buffer={setBufferProgress(dayOfCycle, averLengthOfCycle)}

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -80,7 +80,7 @@ const progressBarStyle = {
 };
 
 function setProgressBar(value: number, maxLength: number) {
-  return (value * 0.95) / maxLength;
+  return (value / maxLength) * 0.95;
 }
 
 const CurrentCycle = () => {

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -79,18 +79,8 @@ const progressBarStyle = {
   marginBottom: "5px" as const,
 };
 
-function setBufferProgress(value: number, averLengthOfCycle: number) {
-  if (averLengthOfCycle > 30) {
-    return Math.min((value / 100) * 2, 0.95);
-  }
-  return Math.min((value / 100) * 3, 0.95);
-}
-
-function setValueProgress(lengthOfPeriod: number, averLengthOfCycle: number) {
-  if (averLengthOfCycle > 30) {
-    return Math.min((lengthOfPeriod / 100) * 2, 0.95);
-  }
-  return Math.min((lengthOfPeriod / 100) * 3, 0.95);
+function setProgressBar(value: number, maxLength: number) {
+  return (value * 0.95) / maxLength;
 }
 
 const CurrentCycle = () => {
@@ -104,7 +94,10 @@ const CurrentCycle = () => {
 
   const startDate = new Date(getLastStartDate(cycles));
   const lengthOfPeriod = cycles[0].periodLength ?? 0;
-  const averLengthOfCycle = getAverageLengthOfCycle(cycles);
+
+  const maxLength = cycles.reduce((max: number, item) => {
+    return Math.max(max, item.cycleLength);
+  }, dayOfCycle);
 
   return (
     <div id="progress-block">
@@ -115,11 +108,11 @@ const CurrentCycle = () => {
         <IonProgressBar
           class="current-progress"
           style={progressBarStyle}
-          value={setValueProgress(
+          value={setProgressBar(
             lengthOfPeriod > dayOfCycle ? dayOfCycle : lengthOfPeriod,
-            averLengthOfCycle,
+            maxLength,
           )}
-          buffer={setBufferProgress(dayOfCycle, averLengthOfCycle)}
+          buffer={setProgressBar(dayOfCycle, maxLength)}
         />
         <IonLabel>
           <p style={datesStyle}>{format(startDate, "MMMM d")}</p>
@@ -135,7 +128,11 @@ interface IdxProps {
 
 const ListProgress = () => {
   const cycles = useContext(CyclesContext).cycles;
-  const lengthOfCycle = getAverageLengthOfCycle(cycles);
+  const dayOfCycle = getDayOfCycle(cycles);
+
+  const maxLength = cycles.reduce((max: number, item) => {
+    return Math.max(max, item.cycleLength);
+  }, dayOfCycle);
 
   const ItemProgress = (props: IdxProps) => {
     const info = useInfoForOneCycle(props.idx + 1);
@@ -151,8 +148,8 @@ const ListProgress = () => {
           </IonLabel>
           <IonProgressBar
             style={progressBarStyle}
-            value={setValueProgress(info.lengthOfPeriod, lengthOfCycle)}
-            buffer={setBufferProgress(info.lengthOfCycleNumber, lengthOfCycle)}
+            value={setProgressBar(info.lengthOfPeriod, maxLength)}
+            buffer={setProgressBar(info.lengthOfCycleNumber, maxLength)}
           />
           <IonLabel>
             <p style={datesStyle}>{info.dates}</p>

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -80,11 +80,11 @@ const progressBarStyle = {
 };
 
 function setBufferProgress(value: number) {
-  return (value / 100) * 3;
+  return (value / 100) * 2.5;
 }
 
 function setValueProgress(lengthOfPeriod: number) {
-  return (lengthOfPeriod / 100) * 3;
+  return (lengthOfPeriod / 100) * 2.5;
 }
 
 const CurrentCycle = () => {

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -79,12 +79,18 @@ const progressBarStyle = {
   marginBottom: "5px" as const,
 };
 
-function setBufferProgress(value: number) {
-  return (value / 100) * 2.5;
+function setBufferProgress(value: number, averLengthOfCycle: number) {
+  if (averLengthOfCycle > 30) {
+    return Math.min((value / 100) * 2, 0.95);
+  }
+  return Math.min((value / 100) * 3, 0.95);
 }
 
-function setValueProgress(lengthOfPeriod: number) {
-  return (lengthOfPeriod / 100) * 2.5;
+function setValueProgress(lengthOfPeriod: number, averLengthOfCycle: number) {
+  if (averLengthOfCycle > 30) {
+    return Math.min((lengthOfPeriod / 100) * 2, 0.95);
+  }
+  return Math.min((lengthOfPeriod / 100) * 3, 0.95);
 }
 
 const CurrentCycle = () => {
@@ -97,7 +103,8 @@ const CurrentCycle = () => {
   })}`;
 
   const startDate = new Date(getLastStartDate(cycles));
-  const lengthOfPeriod = getAverageLengthOfPeriod(cycles);
+  const averLengthOfPeriod = getAverageLengthOfPeriod(cycles);
+  const averLengthOfCycle = getAverageLengthOfCycle(cycles);
 
   return (
     <div id="progress-block">
@@ -109,9 +116,10 @@ const CurrentCycle = () => {
           class="current-progress"
           style={progressBarStyle}
           value={setValueProgress(
-            lengthOfPeriod > dayOfCycle ? dayOfCycle : lengthOfPeriod,
+            averLengthOfPeriod > dayOfCycle ? dayOfCycle : averLengthOfPeriod,
+            averLengthOfCycle,
           )}
-          buffer={setBufferProgress(dayOfCycle)}
+          buffer={setBufferProgress(dayOfCycle, averLengthOfCycle)}
         />
         <IonLabel>
           <p style={datesStyle}>{format(startDate, "MMMM d")}</p>
@@ -127,6 +135,7 @@ interface IdxProps {
 
 const ListProgress = () => {
   const cycles = useContext(CyclesContext).cycles;
+  const lengthOfCycle = getAverageLengthOfCycle(cycles);
 
   const ItemProgress = (props: IdxProps) => {
     const info = useInfoForOneCycle(props.idx + 1);
@@ -142,8 +151,8 @@ const ListProgress = () => {
           </IonLabel>
           <IonProgressBar
             style={progressBarStyle}
-            value={setValueProgress(info.lengthOfPeriod)}
-            buffer={setBufferProgress(info.lengthOfCycleNumber)}
+            value={setValueProgress(info.lengthOfPeriod, lengthOfCycle)}
+            buffer={setBufferProgress(info.lengthOfCycleNumber, lengthOfCycle)}
           />
           <IonLabel>
             <p style={datesStyle}>{info.dates}</p>


### PR DESCRIPTION
Closed #131 

I fixed the display of the progress bar. Now, if the average cycle length is more than 30, then the progress bar length will be less. Also, for a more beautiful display, I added a progress bar of maximum length 0.95 (for example, for the case where there will be a long delay).

Example for average cycle length less than 30:
![image](https://github.com/IraSoro/peri/assets/52165881/97a62869-27c0-4fcb-84b8-e80246af8591)

Example for average cycle length more than 30:
![image](https://github.com/IraSoro/peri/assets/52165881/1ab2df38-b840-4209-ba33-e8f7f598788f)

I fixed the display of the progress bar of the current cycle: now the length of period is `cycles[0].periodLength`, before it was the average value of the period.