### PR TITLE
Calculations of the first cycle in history

### DIFF
--- a/src/modals/InfoModal.tsx
+++ b/src/modals/InfoModal.tsx
@@ -49,7 +49,13 @@ const InfoModal = (props: PropsInfoModal) => {
             postProcess: "interval",
             count: 1, // NOTE: to indicate which day is in the account, you need to write the day as if in the singular
           })} `}
-          {currentDay}/{lengthOfCycle}
+          {cycles.length === 1 ? (
+            currentDay
+          ) : (
+            <>
+              {currentDay}/{lengthOfCycle}
+            </>
+          )}
         </p>
         <ul>
           <li

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -223,7 +223,9 @@ const TabDetails = () => {
                     <IonLabel style={{ marginBottom: "10px" }}>
                       <p style={p_style}>{t("Cycle length")}</p>
                       <p style={h_style}>
-                        {averageLengthOfCycle ? lengthOfCycle : "---"}
+                        {averageLengthOfCycle && cycles.length > 1
+                          ? lengthOfCycle
+                          : "---"}
                       </p>
                     </IonLabel>
                   </div>

--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -272,12 +272,21 @@ const TabHome = (props: HomeProps) => {
             <div>
               <IonLabel>
                 <p
-                  style={{
-                    fontWeight: "bold",
-                    fontSize: "40px",
-                    color: "var(--ion-color-dark-basic)",
-                    marginBottom: "30px",
-                  }}
+                  style={
+                    cycles.length === 1
+                      ? {
+                          fontWeight: "bold",
+                          fontSize: "35px",
+                          color: "var(--ion-color-dark-basic)",
+                          marginBottom: "30px",
+                        }
+                      : {
+                          fontWeight: "bold",
+                          fontSize: "40px",
+                          color: "var(--ion-color-dark-basic)",
+                          marginBottom: "30px",
+                        }
+                  }
                 >
                   {getDaysBeforePeriod(cycles).days}
                 </p>

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -111,6 +111,12 @@ export function getDaysBeforePeriod(cycles: Cycle[]) {
       })}`,
     };
   }
+  if (cycles.length === 1) {
+    return {
+      title: i18n.t("Period is"),
+      days: i18n.t("possible today"),
+    };
+  }
   if (dayBefore === 0) {
     return {
       title: i18n.t("Period"),

--- a/src/tests/CalculationLogic.test.ts
+++ b/src/tests/CalculationLogic.test.ts
@@ -368,6 +368,26 @@ describe("getDaysBeforePeriod", () => {
     });
   });
 
+  test("cycles length is one and period is today", () => {
+    // @ts-expect-error mocked `t` method
+    jest.spyOn(i18n, "t").mockImplementation((key) => key);
+
+    const date = startOfToday();
+
+    const cycles: Cycle[] = [
+      {
+        cycleLength: 28,
+        periodLength: 6,
+        startDate: subDays(date, 28).toString(),
+      },
+    ];
+
+    expect(getDaysBeforePeriod(cycles)).toEqual({
+      title: i18n.t("Period is"),
+      days: i18n.t("possible today"),
+    });
+  });
+
   test("delay 1 day", () => {
     // @ts-expect-error mocked `t` method
     jest.spyOn(i18n, "t").mockImplementation((key) => key);
@@ -415,6 +435,25 @@ describe("getDaysBeforePeriod", () => {
         postProcess: "interval",
         count: 10,
       })}`,
+    });
+  });
+
+  test("cycles length is one and delay a few days", () => {
+    // @ts-expect-error mocked `t` method
+    jest.spyOn(i18n, "t").mockImplementation((key) => key);
+
+    const date = subDays(startOfToday(), 10);
+    const cycles: Cycle[] = [
+      {
+        cycleLength: 28,
+        periodLength: 6,
+        startDate: subDays(date, 28).toString(),
+      },
+    ];
+
+    expect(getDaysBeforePeriod(cycles)).toEqual({
+      title: i18n.t("Period is"),
+      days: i18n.t("possible today"),
     });
   });
 

--- a/src/utils/translations/ru.ts
+++ b/src/utils/translations/ru.ts
@@ -21,6 +21,8 @@ const ru = {
   "You can't mark future days": "Вы не можете отметить будущие дни",
   edit: "редактировать",
   save: "сохранить",
+  "Period is": "Месячные",
+  "possible today": "возможно сегодня",
   // Details Tab
   Details: "Детали",
   "Period length": "Длина месячных",


### PR DESCRIPTION
Closed #140 

I fixed the display of history with one cycle. Now, if only one cycle is marked, the application will look like this
Home tab if period today or delay: 
![image](https://github.com/IraSoro/peri/assets/52165881/8abc6321-6a71-46df-9a17-673631cc8647)
in Russian:
![image](https://github.com/IraSoro/peri/assets/52165881/67f26a27-2db0-4e2e-a9d4-999cb215440b)
I made the "possible today" text size a little smaller. This will only happen if the `cycles.length === 1`.

Details tab:
![image](https://github.com/IraSoro/peri/assets/52165881/2ea0b076-8981-4004-a761-9eb5b7dc7e83)

Info Modal:
![image](https://github.com/IraSoro/peri/assets/52165881/7d9288cc-2170-465a-b6e6-6e41dd790dfe)
