### PR TITLE
More future periods marked

### DIFF
--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -14,7 +14,7 @@ import {
 import { App } from "@capacitor/app";
 import { Capacitor } from "@capacitor/core";
 import { useTranslation } from "react-i18next";
-import { isSameDay, parseISO, startOfDay, startOfToday } from "date-fns";
+import { parseISO } from "date-fns";
 import { CyclesContext } from "../state/Context";
 
 import { storage } from "../data/Storage";
@@ -25,7 +25,6 @@ import InfoModal from "../modals/InfoModal";
 import {
   getPregnancyChance,
   getDaysBeforePeriod,
-  isForecastPeriodToday,
   getNewCyclesHistory,
   getLastPeriodDays,
   getActiveDates,
@@ -98,13 +97,7 @@ const ViewCalendar = (props: SelectCalendarProps) => {
         if (cycles.length === 0) {
           return undefined;
         }
-
-        const date = startOfDay(parseISO(isoDateString));
-        if (isSameDay(date, startOfToday()) && isForecastPeriodToday(cycles)) {
-          return {
-            backgroundColor: "rgba(var(--ion-color-light-basic-rgb), 0.3)",
-          };
-        } else if (forecastPeriodDays.includes(isoDateString)) {
+        if (forecastPeriodDays.includes(isoDateString)) {
           return {
             textColor: "var(--ion-color-dark-basic)",
             backgroundColor: "rgba(var(--ion-color-light-basic-rgb), 0.3)",

--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -25,7 +25,6 @@ import InfoModal from "../modals/InfoModal";
 import {
   getPregnancyChance,
   getDaysBeforePeriod,
-  isForecastPeriodDays,
   isForecastPeriodToday,
   getNewCyclesHistory,
   getLastPeriodDays,
@@ -33,6 +32,7 @@ import {
   getPastFuturePeriodDays,
   isPeriodToday,
   isMarkedFutureDays,
+  getForecastPeriodDays,
 } from "../state/CalculationLogics";
 import { getCurrentTranslation } from "../utils/translation";
 
@@ -84,6 +84,7 @@ const ViewCalendar = (props: SelectCalendarProps) => {
   const { cycles } = useContext(CyclesContext);
 
   const lastPeriodDays = getLastPeriodDays(cycles);
+  const forecastPeriodDays = getForecastPeriodDays(cycles);
 
   return (
     <IonDatetime
@@ -103,7 +104,7 @@ const ViewCalendar = (props: SelectCalendarProps) => {
           return {
             backgroundColor: "rgba(var(--ion-color-light-basic-rgb), 0.3)",
           };
-        } else if (isForecastPeriodDays(date, cycles)) {
+        } else if (forecastPeriodDays.includes(isoDateString)) {
           return {
             textColor: "var(--ion-color-dark-basic)",
             backgroundColor: "rgba(var(--ion-color-light-basic-rgb), 0.3)",

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -370,24 +370,39 @@ export function isForecastPeriodDays(date: Date, cycles: Cycle[]) {
     return false;
   }
 
-  const nextCycleStart = addDays(
-    startOfDay(new Date(cycles[0].startDate)),
-    lengthOfCycle,
-  );
-  const nextCycleFinish = addDays(
-    startOfDay(new Date(cycles[0].startDate)),
-    lengthOfCycle + lengthOfPeriod,
-  );
+  const nextCycleStart = [];
+  const nextCycleFinish = [];
 
-  if (date >= nextCycleStart && date < nextCycleFinish) {
-    return true;
+  const dayOfCycle = getDayOfCycle(cycles);
+  if (dayOfCycle <= lengthOfCycle) {
+    nextCycleStart.push(
+      addDays(startOfDay(new Date(cycles[0].startDate)), lengthOfCycle),
+    );
+    nextCycleFinish.push(
+      addDays(
+        startOfDay(new Date(cycles[0].startDate)),
+        lengthOfCycle + lengthOfPeriod,
+      ),
+    );
+  } else {
+    const delayDate = addDays(startOfToday(), lengthOfPeriod);
+    if (date < delayDate) {
+      return true;
+    }
+    nextCycleStart.push(addDays(nowDate, lengthOfCycle));
+    nextCycleFinish.push(addDays(nowDate, lengthOfCycle + lengthOfPeriod));
   }
 
-  const delayDate = addDays(startOfToday(), lengthOfPeriod);
-  const dayOfCycle = getDayOfCycle(cycles);
+  const cycleCount = 6;
+  for (let i = 0; i < cycleCount; ++i) {
+    nextCycleStart.push(addDays(nextCycleStart[i - 1], lengthOfCycle));
+    nextCycleFinish.push(addDays(nextCycleFinish[i - 1], lengthOfCycle));
+  }
 
-  if (dayOfCycle > lengthOfCycle && date < delayDate) {
-    return true;
+  for (let i = 0; i < cycleCount; ++i) {
+    if (date >= nextCycleStart[i] && date < nextCycleFinish[i]) {
+      return true;
+    }
   }
 
   return false;

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -388,11 +388,13 @@ export function getForecastPeriodDays(cycles: Cycle[]) {
     nextCycleStart = nowDate;
   }
   addForecastDates(nextCycleStart);
+
   const cycleCount = 6;
   for (let i = 0; i < cycleCount; ++i) {
     nextCycleStart = addDays(nextCycleStart, lengthOfCycle);
     addForecastDates(nextCycleStart);
   }
+
   return forecastDates;
 }
 

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -396,20 +396,6 @@ export function getForecastPeriodDays(cycles: Cycle[]) {
   return forecastDates;
 }
 
-export function isForecastPeriodToday(cycles: Cycle[]) {
-  const lengthOfCycle = getAverageLengthOfCycle(cycles);
-  const nowDate = startOfToday();
-
-  const nextCycleStart = new Date(cycles[0].startDate);
-  nextCycleStart.setDate(nextCycleStart.getDate() + lengthOfCycle);
-
-  if (nowDate >= nextCycleStart) {
-    return true;
-  }
-
-  return false;
-}
-
 export function isPeriodToday(cycles: Cycle[]) {
   if (cycles.length === 0) {
     return false;

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -360,52 +360,40 @@ export function getPastFuturePeriodDays(cycles: Cycle[]) {
   return periodDates;
 }
 
-export function isForecastPeriodDays(date: Date, cycles: Cycle[]) {
+export function getForecastPeriodDays(cycles: Cycle[]) {
+  if (cycles.length === 0) {
+    return [];
+  }
+
   const lengthOfCycle = getAverageLengthOfCycle(cycles);
   const lengthOfPeriod = getAverageLengthOfPeriod(cycles);
+  const dayOfCycle = getDayOfCycle(cycles);
   const nowDate = startOfToday();
-  date = startOfDay(date);
 
-  if (date <= nowDate) {
-    return false;
+  let nextCycleStart;
+  const forecastDates: string[] = [];
+
+  function addForecastDates(startDate: Date) {
+    for (let i = 0; i < lengthOfPeriod; ++i) {
+      forecastDates.push(format(addDays(startDate, i), "yyyy-MM-dd"));
+    }
   }
 
-  const nextCycleStart = [];
-  const nextCycleFinish = [];
-
-  const dayOfCycle = getDayOfCycle(cycles);
   if (dayOfCycle <= lengthOfCycle) {
-    nextCycleStart.push(
-      addDays(startOfDay(new Date(cycles[0].startDate)), lengthOfCycle),
-    );
-    nextCycleFinish.push(
-      addDays(
-        startOfDay(new Date(cycles[0].startDate)),
-        lengthOfCycle + lengthOfPeriod,
-      ),
+    nextCycleStart = addDays(
+      startOfDay(new Date(cycles[0].startDate)),
+      lengthOfCycle,
     );
   } else {
-    const delayDate = addDays(startOfToday(), lengthOfPeriod);
-    if (date < delayDate) {
-      return true;
-    }
-    nextCycleStart.push(addDays(nowDate, lengthOfCycle));
-    nextCycleFinish.push(addDays(nowDate, lengthOfCycle + lengthOfPeriod));
+    nextCycleStart = nowDate;
   }
-
+  addForecastDates(nextCycleStart);
   const cycleCount = 6;
   for (let i = 0; i < cycleCount; ++i) {
-    nextCycleStart.push(addDays(nextCycleStart[i - 1], lengthOfCycle));
-    nextCycleFinish.push(addDays(nextCycleFinish[i - 1], lengthOfCycle));
+    nextCycleStart = addDays(nextCycleStart, lengthOfCycle);
+    addForecastDates(nextCycleStart);
   }
-
-  for (let i = 0; i < cycleCount; ++i) {
-    if (date >= nextCycleStart[i] && date < nextCycleFinish[i]) {
-      return true;
-    }
-  }
-
-  return false;
+  return forecastDates;
 }
 
 export function isForecastPeriodToday(cycles: Cycle[]) {


### PR DESCRIPTION
Closed #129 

Now the calendar marks the 6 nearest future cycles. Previously there was only 1.
I changed the `isForecastPeriodDays` function to `getForecastPeriodDays` function. Now the function is called once and returns an array of future dates.  Also I added a new test.

