### PR TITLE
Add min and max limitations for `IonDateTime`

### DIFF
--- a/src/modals/WelcomeModal.tsx
+++ b/src/modals/WelcomeModal.tsx
@@ -9,7 +9,13 @@ import {
   IonDatetime,
 } from "@ionic/react";
 import { useTranslation } from "react-i18next";
-import { parseISO, startOfDay, startOfToday } from "date-fns";
+import {
+  formatISO,
+  parseISO,
+  startOfDay,
+  startOfToday,
+  subMonths,
+} from "date-fns";
 
 import { CyclesContext } from "../state/Context";
 import { getNewCyclesHistory } from "../state/CalculationLogics";
@@ -71,6 +77,8 @@ const Welcome = (props: PropsWelcomeModal) => {
             presentation="date"
             locale={getCurrentTranslation()}
             size="cover"
+            min={formatISO(subMonths(startOfToday(), 6))}
+            max={formatISO(startOfToday())}
             multiple
             firstDayOfWeek={1}
             isDateEnabled={(isoDateString) => {

--- a/src/modals/WelcomeModal.tsx
+++ b/src/modals/WelcomeModal.tsx
@@ -13,6 +13,7 @@ import {
   formatISO,
   parseISO,
   startOfDay,
+  startOfMonth,
   startOfToday,
   subMonths,
 } from "date-fns";
@@ -77,7 +78,7 @@ const Welcome = (props: PropsWelcomeModal) => {
             presentation="date"
             locale={getCurrentTranslation()}
             size="cover"
-            min={formatISO(subMonths(startOfToday(), 6))}
+            min={formatISO(startOfMonth(subMonths(startOfToday(), 6)))}
             max={formatISO(startOfToday())}
             multiple
             firstDayOfWeek={1}

--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -14,7 +14,14 @@ import {
 import { App } from "@capacitor/app";
 import { Capacitor } from "@capacitor/core";
 import { useTranslation } from "react-i18next";
-import { parseISO, startOfToday, format } from "date-fns";
+import {
+  parseISO,
+  startOfToday,
+  format,
+  formatISO,
+  subMonths,
+  min,
+} from "date-fns";
 import { CyclesContext } from "../state/Context";
 
 import { storage } from "../data/Storage";
@@ -87,6 +94,22 @@ const ViewCalendar = (props: SelectCalendarProps) => {
   const forecastPeriodDays = getForecastPeriodDays(cycles);
   const ovulationDays = getOvulationDays(cycles);
 
+  const firstPeriodDay = lastPeriodDays
+    .sort((left, right) => {
+      const leftDate = new Date(left);
+      const rightDate = new Date(right);
+      return leftDate.getTime() - rightDate.getTime();
+    })
+    .at(0);
+
+  const firstPeriodDayDate = firstPeriodDay
+    ? parseISO(firstPeriodDay)
+    : startOfToday();
+
+  const minDate = formatISO(
+    min([firstPeriodDayDate, subMonths(startOfToday(), 6)]),
+  );
+
   return (
     <IonDatetime
       className={
@@ -97,6 +120,8 @@ const ViewCalendar = (props: SelectCalendarProps) => {
       presentation="date"
       locale={getCurrentTranslation()}
       size="cover"
+      min={minDate}
+      max={formatISO(startOfToday())}
       firstDayOfWeek={1}
       highlightedDates={(isoDateString) => {
         if (cycles.length === 0) {
@@ -146,6 +171,22 @@ const EditCalendar = (props: SelectCalendarProps) => {
 
   const lastPeriodDays = getLastPeriodDays(cycles);
 
+  const firstPeriodDay = lastPeriodDays
+    .sort((left, right) => {
+      const leftDate = new Date(left);
+      const rightDate = new Date(right);
+      return leftDate.getTime() - rightDate.getTime();
+    })
+    .at(0);
+
+  const firstPeriodDayDate = firstPeriodDay
+    ? parseISO(firstPeriodDay)
+    : startOfToday();
+
+  const minDate = formatISO(
+    min([firstPeriodDayDate, subMonths(startOfToday(), 6)]),
+  );
+
   return (
     <IonDatetime
       className="edit-calendar"
@@ -153,6 +194,8 @@ const EditCalendar = (props: SelectCalendarProps) => {
       presentation="date"
       locale={getCurrentTranslation()}
       size="cover"
+      min={minDate}
+      max={formatISO(startOfToday())}
       multiple
       firstDayOfWeek={1}
       // NOTE: Please don't remove `reverse` here, more info https://github.com/IraSoro/peri/issues/157

--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -21,6 +21,10 @@ import {
   formatISO,
   subMonths,
   min,
+  startOfMonth,
+  endOfMonth,
+  addMonths,
+  max,
 } from "date-fns";
 import { CyclesContext } from "../state/Context";
 
@@ -110,6 +114,22 @@ const ViewCalendar = (props: SelectCalendarProps) => {
     startOfMonth(min([firstPeriodDayDate, subMonths(startOfToday(), 6)])),
   );
 
+  const lastForecastPeriodDay = forecastPeriodDays
+    .sort((left, right) => {
+      const leftDate = new Date(left);
+      const rightDate = new Date(right);
+      return leftDate.getTime() - rightDate.getTime();
+    })
+    .at(-1);
+
+  const lastForecastPeriodDayDate = lastForecastPeriodDay
+    ? endOfMonth(parseISO(lastForecastPeriodDay))
+    : endOfMonth(startOfToday());
+
+  const maxDate = formatISO(
+    endOfMonth(max([lastForecastPeriodDayDate, addMonths(startOfToday(), 6)])),
+  );
+
   return (
     <IonDatetime
       className={
@@ -121,7 +141,7 @@ const ViewCalendar = (props: SelectCalendarProps) => {
       locale={getCurrentTranslation()}
       size="cover"
       min={minDate}
-      max={formatISO(startOfToday())}
+      max={maxDate}
       firstDayOfWeek={1}
       highlightedDates={(isoDateString) => {
         if (cycles.length === 0) {

--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -144,14 +144,7 @@ const EditCalendar = (props: SelectCalendarProps) => {
   const { t } = useTranslation();
   const { cycles, updateCycles } = useContext(CyclesContext);
 
-  useEffect(() => {
-    if (!datetimeRef.current) return;
-    const lastPeriodDays = getLastPeriodDays(cycles);
-    if (!lastPeriodDays.length) {
-      return;
-    }
-    datetimeRef.current.value = lastPeriodDays;
-  }, [cycles]);
+  const lastPeriodDays = getLastPeriodDays(cycles);
 
   return (
     <IonDatetime
@@ -162,6 +155,8 @@ const EditCalendar = (props: SelectCalendarProps) => {
       size="cover"
       multiple
       firstDayOfWeek={1}
+      // NOTE: Please don't remove `reverse` here, more info https://github.com/IraSoro/peri/issues/157
+      value={lastPeriodDays.reverse()}
       isDateEnabled={(isoDateString) => {
         return getActiveDates(parseISO(isoDateString), cycles);
       }}

--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -110,9 +110,7 @@ const ViewCalendar = (props: SelectCalendarProps) => {
     ? parseISO(firstPeriodDay)
     : startOfToday();
 
-  const minDate = formatISO(
-    startOfMonth(min([firstPeriodDayDate, subMonths(startOfToday(), 6)])),
-  );
+  const minDate = formatISO(startOfMonth(firstPeriodDayDate));
 
   const lastForecastPeriodDay = forecastPeriodDays
     .sort((left, right) => {

--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -107,7 +107,7 @@ const ViewCalendar = (props: SelectCalendarProps) => {
     : startOfToday();
 
   const minDate = formatISO(
-    min([firstPeriodDayDate, subMonths(startOfToday(), 6)]),
+    startOfMonth(min([firstPeriodDayDate, subMonths(startOfToday(), 6)])),
   );
 
   return (
@@ -184,7 +184,7 @@ const EditCalendar = (props: SelectCalendarProps) => {
     : startOfToday();
 
   const minDate = formatISO(
-    min([firstPeriodDayDate, subMonths(startOfToday(), 6)]),
+    startOfMonth(min([firstPeriodDayDate, subMonths(startOfToday(), 6)])),
   );
 
   return (


### PR DESCRIPTION
Closed #153 

Now the maximum value is equals to current month
The minimum value is calculated based on the following logic. We getting first date of the first period and if this date is further than 6 months from today then this date will be min limitation, if this date is nearest than 6 months then 6 months from today will be the minimum for the `IonDateTime`