### PR TITLE
Disabled month/year selection

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -118,16 +118,26 @@ ion-datetime::part(calendar-day active):focus {
   color: var(--ion-color-dark-basic);
 }
 
+ion-datetime.welcome-calendar::part(month-year-button) {
+  pointer-events: none;
+}
+
 ion-datetime.edit-calendar::part(calendar-day active),
 ion-datetime.edit-calendar::part(calendar-day active):focus {
   color: var(--ion-color-blackout-basic);
   border: 2px dotted var(--ion-color-blackout-basic);
   background-color: var(--ion-color-light);
 }
+ion-datetime.edit-calendar::part(month-year-button) {
+  pointer-events: none;
+}
 
 ion-datetime.view-calendar-today-ovulation::part(calendar-day today) {
   color: var(--ion-color-ovulation);
   border-color: var(--ion-color-ovulation);
+}
+ion-datetime.view-calendar::part(month-year-button) {
+  pointer-events: none;
 }
 
 ion-datetime.view-calendar::part(calendar-day):focus,

--- a/src/modals/WelcomeModal.tsx
+++ b/src/modals/WelcomeModal.tsx
@@ -74,6 +74,7 @@ const Welcome = (props: PropsWelcomeModal) => {
         </div>
         <div style={{ marginBottom: "20px" }}>
           <IonDatetime
+            className="welcome-calendar"
             ref={datetimeRef}
             presentation="date"
             locale={getCurrentTranslation()}


### PR DESCRIPTION
Closes #152
Closes #154

We have 2 problems related to month/year selector. The same behavior reproduces with a default ion datetime and may be checked here https://ionicframework.com/docs/api/datetime

I tried to use all available props, css and callbacks to get rid of these bugs, but unsuccessfully.

After this I tried to think about user behavior and decided to disable month/year selection, because user has all necessary information about the previous periods in the `Details` tab. If the user needs to see specific month their should scroll back month by month. It takes longer, but does not conflict with the basic behavior of our users in my opinion

The only problem that remains is this arrow icon, I tried different css selectors, but I couldn’t get to this element and make it invisible
![image](https://github.com/IraSoro/peri/assets/28269602/cccaffb7-36bf-4dba-a9ca-1ef77f31ea4b)
