### PR TITLE
Fixed version view

### DIFF
--- a/src/modals/Menu.tsx
+++ b/src/modals/Menu.tsx
@@ -191,8 +191,12 @@ export const Menu = (props: MenuProps) => {
         )}
       </IonList>
       <IonItem>
-        <IonLabel color="medium">
-          The Period Tracker App Peri {appVersion}
+        <IonLabel color="medium">Peri - The Period Tracker App</IonLabel>
+        <IonLabel
+          color="medium"
+          slot="end"
+        >
+          {appVersion}
         </IonLabel>
       </IonItem>
     </IonMenu>

--- a/src/modals/Menu.tsx
+++ b/src/modals/Menu.tsx
@@ -191,8 +191,14 @@ export const Menu = (props: MenuProps) => {
         )}
       </IonList>
       <IonItem>
-        <IonLabel color="medium">Peri - The Period Tracker App</IonLabel>
         <IonLabel
+          style={{ fontSize: "13px" }}
+          color="medium"
+        >
+          Peri - The Period Tracker App
+        </IonLabel>
+        <IonLabel
+          style={{ fontSize: "13px" }}
           color="medium"
           slot="end"
         >


### PR DESCRIPTION
Closes #156

I experimented with two lines and it looks like this
![Screenshot from 2023-11-23 20-42-31](https://github.com/IraSoro/peri/assets/28269602/861f07f1-41d7-4682-9feb-36e175c6adb4)
For me it's looks bad, so I decided to user another version where `Peri the period tracker app` will be cut off with `...`, but version always will be visible on the right side
![image](https://github.com/IraSoro/peri/assets/28269602/3ae2a776-3eee-446e-8377-4c267ff7cfaa)
