### PR TITLE
Fixed case if user removes all cycles

### DIFF
--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -138,7 +138,6 @@ const ViewCalendar = (props: SelectCalendarProps) => {
 
 const EditCalendar = (props: SelectCalendarProps) => {
   const datetimeRef = useRef<null | HTMLIonDatetimeElement>(null);
-  const [cannotSaveAlert] = useIonAlert();
 
   const { t } = useTranslation();
   const { cycles, updateCycles } = useContext(CyclesContext);

--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -30,7 +30,6 @@ import {
   getActiveDates,
   getPastFuturePeriodDays,
   isPeriodToday,
-  isMarkedFutureDays,
   getForecastPeriodDays,
   getOvulationDays,
 } from "../state/CalculationLogics";
@@ -178,26 +177,16 @@ const EditCalendar = (props: SelectCalendarProps) => {
         <IonButton
           color="blackout-basic"
           onClick={() => {
+            // NOTE: `confirm` should be called to update values in `datetimeRef`
             datetimeRef.current?.confirm().catch((err) => console.error(err));
-            if (datetimeRef.current?.value) {
-              const periodDaysString = (
-                datetimeRef.current.value as string[]
-              ).map((isoDateString) => {
-                return parseISO(isoDateString).toString();
-              });
 
-              if (isMarkedFutureDays(periodDaysString)) {
-                datetimeRef.current.value = getLastPeriodDays(cycles);
+            const periodDaysString = (
+              (datetimeRef.current?.value as string[]) ?? []
+            ).map((isoDateString) => {
+              return parseISO(isoDateString).toString();
+            });
 
-                cannotSaveAlert({
-                  header: t("You can't mark future days"),
-                  buttons: ["OK"],
-                }).catch((err) => console.error(err));
-
-                return;
-              }
-              updateCycles(getNewCyclesHistory(periodDaysString));
-            }
+            updateCycles(getNewCyclesHistory(periodDaysString));
             props.setIsEditCalendar(false);
           }}
         >

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -5,7 +5,6 @@ import {
   parseISO,
   startOfDay,
   startOfToday,
-  differenceInMilliseconds,
 } from "date-fns";
 
 import { Cycle } from "../data/ClassCycle";

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -411,24 +411,6 @@ export function isPeriodToday(cycles: Cycle[]) {
   return dayOfCycle <= cycles[0].periodLength;
 }
 
-export function isMarkedFutureDays(periodDays: string[]) {
-  periodDays.sort((left, right) => {
-    const leftDate = startOfDay(new Date(left));
-    const rightDate = startOfDay(new Date(right));
-    return differenceInMilliseconds(leftDate, rightDate);
-  });
-
-  const today = startOfToday();
-
-  if (periodDays.includes(today.toString())) {
-    return false;
-  }
-
-  return periodDays.some((date) => {
-    return startOfDay(new Date(date)) > today;
-  });
-}
-
 export function getOvulationDays(cycles: Cycle[]) {
   if (cycles.length < 2) {
     return [];

--- a/src/tests/CalculationLogic.test.ts
+++ b/src/tests/CalculationLogic.test.ts
@@ -24,7 +24,6 @@ import {
   getPastFuturePeriodDays,
   getLastStartDate,
   getLengthOfLastPeriod,
-  isMarkedFutureDays,
   getForecastPeriodDays,
   getOvulationDays,
 } from "../state/CalculationLogics";
@@ -984,51 +983,6 @@ describe("getLengthOfLastPeriod", () => {
     }
 
     expect(getLengthOfLastPeriod(cycles)).toEqual(cycles[0].periodLength);
-  });
-});
-
-describe("isMarkedFutureDays", () => {
-  test("nothing marked", () => {
-    expect(isMarkedFutureDays([])).toEqual(false);
-  });
-
-  test("past periods marked", () => {
-    // @ts-expect-error mocked `t` method
-    jest.spyOn(i18n, "t").mockImplementation((key) => key);
-    const dates: string[] = [];
-
-    for (let i = 5; i < 10; ++i) {
-      dates.push(subDays(startOfToday(), i).toString());
-    }
-
-    expect(isMarkedFutureDays(dates)).toEqual(false);
-  });
-
-  test("period now marked", () => {
-    // @ts-expect-error mocked `t` method
-    jest.spyOn(i18n, "t").mockImplementation((key) => key);
-    const dates: string[] = [];
-
-    for (let i = 0; i < 3; ++i) {
-      dates.push(subDays(startOfToday(), i).toString());
-    }
-    for (let i = 1; i < 3; ++i) {
-      dates.push(addDays(startOfToday(), i).toString());
-    }
-
-    expect(isMarkedFutureDays(dates)).toEqual(false);
-  });
-
-  test("future days are marked", () => {
-    // @ts-expect-error mocked `t` method
-    jest.spyOn(i18n, "t").mockImplementation((key) => key);
-    const dates: string[] = [];
-
-    for (let i = 1; i < 6; ++i) {
-      dates.push(addDays(startOfToday(), i).toString());
-    }
-
-    expect(isMarkedFutureDays(dates)).toEqual(true);
   });
 });
 

--- a/src/utils/translations/ru.ts
+++ b/src/utils/translations/ru.ts
@@ -18,7 +18,6 @@ const ru = {
   High: "Высокая",
   Low: "Низкая",
   "Period today": "Месячные сегодня",
-  "You can't mark future days": "Вы не можете отметить будущие дни",
   edit: "редактировать",
   save: "сохранить",
   "Period is": "Месячные",


### PR DESCRIPTION
Fixed #166

In this PR I added possibility to save empty array of cycles. Also I removed `isMarkedFutureDays` because now we using ion-datetime built-in limitation instead of custom checks

New test has been added https://github.com/IraSoro/peri/issues/192