### PR TITLE
Disabled possibility to select any date on the calendar's view mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -125,15 +125,6 @@ ion-datetime.edit-calendar::part(calendar-day active):focus {
   background-color: var(--ion-color-light);
 }
 
-ion-datetime.view-calendar::part(calendar-day active),
-ion-datetime.view-calendar::part(calendar-day active):focus,
-ion-datetime.view-calendar-today-ovulation::part(calendar-day active),
-ion-datetime.view-calendar-today-ovulation::part(calendar-day active):focus {
-  background-color: var(--ion-color-light);
-  color: var(--ion-color-dark);
-  border-color: var(--ion-color-light);
-}
-
 ion-datetime.view-calendar-today-ovulation::part(calendar-day today) {
   color: var(--ion-color-ovulation);
   border-color: var(--ion-color-ovulation);
@@ -144,4 +135,7 @@ ion-datetime.edit-calendar::part(calendar-day):focus,
 ion-datetime.view-calendar-today-ovulation::part(calendar-day):focus {
   background-color: #fff;
   box-shadow: 0px 0px 0px 0px #fff;
+}
+ion-datetime.view-calendar::part(calendar-day) {
+  pointer-events: none;
 }


### PR DESCRIPTION
I didn't find related task in the `Issues` list

Previously when you click on today, border is disappeared
![image](https://github.com/IraSoro/peri/assets/28269602/c077fe82-7deb-4551-8494-be4fb0c2d26f)
![image](https://github.com/IraSoro/peri/assets/28269602/b98fa05b-0f85-449e-9e19-d3fd4a065d5a)
![image](https://github.com/IraSoro/peri/assets/28269602/606e1909-3eb5-440f-b872-e0ea16fc416a)

The similar problem was for ovulation days
![image](https://github.com/IraSoro/peri/assets/28269602/ddce1df9-e874-41be-909b-6ce666a27bb1)

I disabled possibility to handle events on the days when you in the calendar's view mode. With this restriction you can click on any day and a click event will be ignored, but you still able to move between months