### PR TITLE
Fixed dark theme's `IonSelect` style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -190,6 +190,15 @@ ion-select.dark::part(text),
 ion-select.dark::part(icon) {
   color: var(--ion-color-text-dark);
 }
+ion-popover.dark {
+  --background: var(--ion-color-transparent-dark);
+}
+ion-popover.dark * {
+  color: white;
+}
+ion-popover.dark .item-radio-checked {
+  background-color: var(--ion-color-dark-dark);
+}
 
 ion-datetime.welcome-calendar-dark,
 ion-datetime.edit-calendar-dark,

--- a/src/modals/Menu.tsx
+++ b/src/modals/Menu.tsx
@@ -68,6 +68,9 @@ const LanguageSwitcher = () => {
         className={theme}
         value={getCurrentTranslation()}
         interface="popover"
+        interfaceOptions={{
+          cssClass: theme,
+        }}
         onIonChange={(event) => {
           changeLanguage(event.target.value as string).catch((err) => {
             console.error(err);
@@ -109,6 +112,9 @@ const ThemeSwitcher = () => {
         className={theme}
         value={theme === "dark" ? "dark (beta)" : theme}
         interface="popover"
+        interfaceOptions={{
+          cssClass: theme,
+        }}
         onIonChange={(event) => updateTheme(event.target.value as string)}
       >
         {themesList}


### PR DESCRIPTION
Closed #216 
I fixed style for `IonSelect` component in case of dark theme
This is how it looks like:
![image](https://github.com/IraSoro/peri/assets/28269602/efd37f3d-eb80-4a38-a735-45b94024c20e)

I'm not sure about this styling, maybe it's could be better to use the same color scheme which we use for buttons or other interactive elements, something like this:
![image](https://github.com/IraSoro/peri/assets/28269602/48ce13dc-a288-4043-9094-a05626156f0c)

```css
ion-popover.dark {
  --background: var(--ion-color-dark-dark);
}
ion-popover.dark * {
  color: #000000;
}
ion-popover.dark .item-radio-checked {
  background-color: var(--ion-color-dark-dark);
}
```

@IraSoro what do you think about that?