### PR TITLE
Removed `nodejs 18` from matrix and added ci check on `main` push

### DIFF
--- a/.github/workflows/build_lint_test.yml
+++ b/.github/workflows/build_lint_test.yml
@@ -3,6 +3,8 @@ name: Build, lint and test
 on:
   pull_request:
     branches: [ "master" ]
+  push:
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -11,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Now `peri` code is checked and tested separately in every branch. I added additional ci check to test `main` branch in general with all merged changes

Additionally, I removed `nodejs 18` from matrix because this version is in maintenance now and not in active developmentю More info here https://nodejs.org/en/about/previous-releases