### PR TITLE
Renamed `basic` color

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,9 @@ const App = (props: AppProps) => {
     if (newTheme === "dark (beta)") {
       newTheme = "dark";
     }
+    if (newTheme === "light") {
+      newTheme = "basic";
+    }
     setTheme(newTheme);
     storage.set.theme(newTheme).catch((err) => console.error(err));
   }

--- a/src/modals/Menu.tsx
+++ b/src/modals/Menu.tsx
@@ -88,7 +88,7 @@ const ThemeSwitcher = () => {
   const { theme, updateTheme } = useContext(ThemeContext);
 
   const themesList = [];
-  for (const item of ["basic", "dark (beta)"]) {
+  for (const item of ["light", "dark (beta)"]) {
     themesList.push(
       <IonSelectOption
         key={item}
@@ -110,7 +110,9 @@ const ThemeSwitcher = () => {
       <IonLabel color={`text-${theme}`}>{t("Theme")}</IonLabel>
       <IonSelect
         className={theme}
-        value={theme === "dark" ? "dark (beta)" : theme}
+        value={
+          theme === "dark" ? "dark (beta)" : theme === "basic" ? "light" : theme
+        }
         interface="popover"
         interfaceOptions={{
           cssClass: theme,


### PR DESCRIPTION
Closed #229 

I renamed a `basic` theme to `light` theme.  It looks like this
![image](https://github.com/IraSoro/peri/assets/52165881/bdd865fa-6811-443a-b87a-590059138104)

But I didn't change the color names and style names in the css-files. I don't know if I should do this. Now we have a basic color. If I rename it, there will be confusion because by default Ionic has a light color.