### PR TITLE
Made large the height of the empty `Info button`

### DIFF
--- a/src/pages/TabHome.tsx
+++ b/src/pages/TabHome.tsx
@@ -60,13 +60,10 @@ const InfoButton = (props: InfoButtonProps) => {
 
   const pregnancyChance = getPregnancyChance(cycles);
   if (cycles.length === 0) {
-    return <></>;
+    return <p style={{ marginBottom: "20px", height: "20px" }}></p>;
   }
   return (
-    <IonLabel
-      class="info-button"
-      onClick={() => props.setIsInfoModal(true)}
-    >
+    <IonLabel onClick={() => props.setIsInfoModal(true)}>
       <p
         style={{
           fontSize: "14px",


### PR DESCRIPTION
Closed #231 

Previously, when the cycles were empty, the `Info button` simply didn`t display. Now I've added an empty space in this case. So that the calendar and the `Mark button` don't move when updating.