### PR TITLE
New tab design Details

### DIFF
--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -17,23 +17,38 @@
   height: 70px;
 }
 
-p.h_style {
-  font-size: 20px;
-  color: var(--ion-color-light);
+p.h_style-basic {
+  font-size: 22px;
+  color: var(--ion-color-dark-basic);
   margin-top: 10px;
+  font-weight: bold;
+}
+
+p.h_style-dark {
+  font-size: 22px;
+  color: var(--ion-color-dark-dark);
+  margin-top: 10px;
+  font-weight: bold;
 }
 
 p.p_style {
-  font-size: 12px;
-  color: var(--ion-color-light);
+  font-size: 13px;
+  color: var(--ion-color-medium);
   margin-top: 5px;
 }
 
-#vertical-line {
+#vertical-line-basic {
   width: 2px;
   height: 70px;
   margin-top: 5px;
-  background: var(--ion-color-light);
+  background: #e2e3e7;
+}
+
+#vertical-line-dark {
+  width: 2px;
+  height: 70px;
+  margin-top: 5px;
+  background: #717274;
 }
 
 #progress-block {

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -1,4 +1,4 @@
-#width-details-screen{
+#width-details-screen {
   max-width: 320px;
 
   margin-left: auto;

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -1,5 +1,5 @@
 #inline-block {
-  width: 149px;
+  width: 150px;
 
   display: flex;
   flex-direction: column;
@@ -31,9 +31,9 @@ ion-label.average-values-title{
 }
 
 #progress-block {
-  width: 300px;
-  height: 70px;
-  border-radius: 20px;
+  max-width: 320px;
+  width: 100%;
+  border-radius: 15px;
 
   display: flex;
   flex-direction: column;

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -11,17 +11,21 @@
 #average-length {
   width: 300px;
   height: 75px;
-  border-radius: 20px;
+  border-radius: 15px;
 
   display: flex;
 }
 
 #inline-block {
   width: 149px;
-  border-radius: 20px;
+  border-radius: 15px;
 
   margin-left: 15px;
   margin-right: 15px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 #vertical-line {

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -38,6 +38,11 @@ p.p_style {
   margin-top: 5px;
 }
 
+p.no-periods {
+  font-size: 13px;
+  text-align: center;
+}
+
 #vertical-line-basic {
   width: 2px;
   height: 70px;

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -1,3 +1,17 @@
+#width-details-screen{
+  max-width: 320px;
+
+  margin-left: auto;
+  margin-right: auto;
+}
+
+#general-block {
+  margin-bottom: 15px;
+  border-radius: 15px;
+  height: 90px;
+  width: 100%;
+}
+
 #inline-block {
   width: 150px;
 
@@ -19,7 +33,10 @@ ion-label.average-value {
   flex-direction: column;
 }
 
-ion-label.average-values-title{
+ion-label.average-values-title {
+  font-size: 17px;
+  color: var(--ion-color-light);
+
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -31,18 +48,26 @@ ion-label.average-values-title{
 }
 
 #progress-block {
-  max-width: 320px;
   width: 100%;
   border-radius: 15px;
-
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
 }
 
 ion-progress-bar {
   height: 8px;
   border-radius: 20px;
+}
+
+p.p_style {
+  font-size: 12px;
+  color: var(--ion-color-light);
+  text-align: left;
+  margin-bottom: 5px;
+}
+
+p.h_style {
+  font-size: 20px;
+  color: var(--ion-color-light);
+  text-align: left;
 }
 
 ion-progress-bar.current-progress-basic,

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -1,3 +1,26 @@
+#inline-block {
+  width: 149px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+ion-label.average-value {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+
+ion-label.average-values-title{
+  display: flex;
+
+  padding-left: 10px;
+  padding-top: 5px;
+  padding-bottom: 10px;
+}
+
 #progress-block {
   width: 300px;
   height: 70px;
@@ -6,32 +29,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-}
-
-#average-length {
-  width: 300px;
-  height: 75px;
-  border-radius: 15px;
-
-  display: flex;
-}
-
-#inline-block {
-  width: 149px;
-  border-radius: 15px;
-
-  margin-left: 15px;
-  margin-right: 15px;
-
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-#vertical-line {
-  width: 2px;
-  height: 55px;
-  background: var(--ion-color-light);
 }
 
 ion-progress-bar {

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -6,7 +6,8 @@
 }
 
 #general-block {
-  margin-bottom: 15px;
+  margin-top: 10px;
+  margin-bottom: 25px;
   border-radius: 15px;
   height: 90px;
   width: 100%;

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -7,6 +7,12 @@
   align-items: center;
 }
 
+#vertical-line {
+  width: 2px;
+  height: 40px;
+  background: var(--ion-color-light);
+}
+
 ion-label.average-value {
   align-items: center;
   display: flex;
@@ -15,6 +21,9 @@ ion-label.average-value {
 
 ion-label.average-values-title{
   display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 
   padding-left: 10px;
   padding-top: 5px;

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -50,6 +50,9 @@ ion-label.average-values-title {
 #progress-block {
   width: 100%;
   border-radius: 15px;
+
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 ion-progress-bar {

--- a/src/pages/TabDetails.css
+++ b/src/pages/TabDetails.css
@@ -14,37 +14,26 @@
 
 #inline-block {
   width: 150px;
+  height: 70px;
+}
 
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+p.h_style {
+  font-size: 20px;
+  color: var(--ion-color-light);
+  margin-top: 10px;
+}
+
+p.p_style {
+  font-size: 12px;
+  color: var(--ion-color-light);
+  margin-top: 5px;
 }
 
 #vertical-line {
   width: 2px;
-  height: 40px;
+  height: 70px;
+  margin-top: 5px;
   background: var(--ion-color-light);
-}
-
-ion-label.average-value {
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-}
-
-ion-label.average-values-title {
-  font-size: 17px;
-  color: var(--ion-color-light);
-
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  padding-left: 10px;
-  padding-top: 5px;
-  padding-bottom: 10px;
 }
 
 #progress-block {
@@ -58,19 +47,6 @@ ion-label.average-values-title {
 ion-progress-bar {
   height: 8px;
   border-radius: 20px;
-}
-
-p.p_style {
-  font-size: 12px;
-  color: var(--ion-color-light);
-  text-align: left;
-  margin-bottom: 5px;
-}
-
-p.h_style {
-  font-size: 20px;
-  color: var(--ion-color-light);
-  text-align: left;
 }
 
 ion-progress-bar.current-progress-basic,

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -254,11 +254,9 @@ const TabDetails = () => {
                   {cycles.length > 1 && <ListProgress />}
                 </IonList>
               ) : (
-                <div id="progress-block">
-                  <p style={{ fontSize: "13px" }}>
-                    {t("You haven't marked any periods yet")}
-                  </p>
-                </div>
+                <p className="no-periods">
+                  {t("You haven't marked any periods yet")}
+                </p>
               )}
             </div>
           </div>

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -140,7 +140,7 @@ const ListProgress = () => {
     const info = useInfoForOneCycle(props.idx + 1);
 
     return (
-      <div style={{ marginTop: "15px" }}>
+      <div style={{ marginTop: "20px" }}>
         <div style={{ marginLeft: "15px" }}>
           <IonLabel>
             <p style={lenCycleStyle}>{info.lengthOfCycleString}</p>

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -103,27 +103,22 @@ const CurrentCycle = () => {
   }, dayOfCycle);
 
   return (
-    <div
-      id="progress-block"
-      style={{ background: `var(--ion-color-calendar-${theme})` }}
-    >
-      <div style={{ marginLeft: "15px" }}>
-        <IonLabel>
-          <p style={lenCycleStyle}>{title}</p>
-        </IonLabel>
-        <IonProgressBar
-          className={`current-progress-${theme}`}
-          style={progressBarStyle}
-          value={setProgressBar(
-            lengthOfPeriod > dayOfCycle ? dayOfCycle : lengthOfPeriod,
-            maxLength,
-          )}
-          buffer={setProgressBar(dayOfCycle, maxLength)}
-        />
-        <IonLabel>
-          <p style={datesStyle}>{format(startDate, "MMMM d")}</p>
-        </IonLabel>
-      </div>
+    <div style={{ marginLeft: "15px" }}>
+      <IonLabel>
+        <p style={lenCycleStyle}>{title}</p>
+      </IonLabel>
+      <IonProgressBar
+        className={`current-progress-${theme}`}
+        style={progressBarStyle}
+        value={setProgressBar(
+          lengthOfPeriod > dayOfCycle ? dayOfCycle : lengthOfPeriod,
+          maxLength,
+        )}
+        buffer={setProgressBar(dayOfCycle, maxLength)}
+      />
+      <IonLabel>
+        <p style={datesStyle}>{format(startDate, "MMMM d")}</p>
+      </IonLabel>
     </div>
   );
 };
@@ -145,13 +140,7 @@ const ListProgress = () => {
     const info = useInfoForOneCycle(props.idx + 1);
 
     return (
-      <div
-        id="progress-block"
-        style={{
-          marginTop: "15px",
-          background: `var(--ion-color-calendar-${theme})`,
-        }}
-      >
+      <div style={{ marginTop: "15px" }}>
         <div style={{ marginLeft: "15px" }}>
           <IonLabel>
             <p style={lenCycleStyle}>{info.lengthOfCycleString}</p>
@@ -223,8 +212,7 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
     <div
       style={{
         marginBottom: "15px",
-        borderRadius: "14px",
-        width: "320px",
+        borderRadius: "15px",
         height: "90px",
         background: `var(--ion-color-less-dark-${theme})`,
       }}
@@ -285,18 +273,23 @@ const TabDetails = () => {
               <AverageValues cycles={cycles} />
             </IonCol>
             <IonCol>
-              {cycles.length > 0 ? (
-                <IonList>
-                  <CurrentCycle />
-                  {cycles.length > 1 && <ListProgress />}
-                </IonList>
-              ) : (
-                <div id="progress-block">
-                  <p style={{ fontSize: "13px" }}>
-                    {t("You haven't marked any periods yet")}
-                  </p>
-                </div>
-              )}
+              <div
+                id="progress-block"
+                style={{ background: `var(--ion-color-calendar-${theme})` }}
+              >
+                {cycles.length > 0 ? (
+                  <IonList>
+                    <CurrentCycle />
+                    {cycles.length > 1 && <ListProgress />}
+                  </IonList>
+                ) : (
+                  <div id="progress-block">
+                    <p style={{ fontSize: "13px" }}>
+                      {t("You haven't marked any periods yet")}
+                    </p>
+                  </div>
+                )}
+              </div>
             </IonCol>
           </div>
         </IonContent>

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -221,16 +221,26 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
 
   return (
     <div
-      id="average-length"
       style={{
         marginBottom: "15px",
+        borderRadius: "14px",
         width: "300px",
+        height: "90px",
         background: `var(--ion-color-less-dark-${theme})`,
       }}
     >
+      <IonLabel
+        className="average-values-title"
+        style={{
+          fontSize: "17px",
+          color: "var(--ion-color-light)",
+        }}
+      >
+        Average values
+      </IonLabel>
       <IonCol>
         <div id="inline-block">
-          <IonLabel>
+          <IonLabel className="average-value">
             <p style={h_style}>
               {averageLengthOfCycle && cycles.length > 1
                 ? lengthOfCycle
@@ -240,7 +250,7 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
           </IonLabel>
         </div>
         <div id="inline-block">
-          <IonLabel>
+          <IonLabel className="average-value">
             <p style={h_style}>
               {averageLengthOfPeriod ? lengthOfPeriod : "---"}
             </p>

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -198,12 +198,12 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
   return (
     <div
       id="general-block"
-      style={{ background: `var(--ion-color-less-dark-${theme})` }}
+      style={{ background: `var(--ion-color-calendar-${theme})` }}
     >
       <IonCol>
         <div id="inline-block">
           <IonLabel className="average-value">
-            <p className="h_style">
+            <p className={`h_style-${theme}`}>
               {averageLengthOfCycle && cycles.length > 1
                 ? lengthOfCycle
                 : "---"}
@@ -211,10 +211,10 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
             <p className="p_style">{t("Cycle length")}</p>
           </IonLabel>
         </div>
-        <div id="vertical-line" />
+        <div id={`vertical-line-${theme}`} />
         <div id="inline-block">
           <IonLabel className="average-value">
-            <p className="h_style">
+            <p className={`h_style-${theme}`}>
               {averageLengthOfPeriod ? lengthOfPeriod : "---"}
             </p>
             <p className="p_style">{t("Period length")}</p>

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -200,7 +200,6 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
       id="general-block"
       style={{ background: `var(--ion-color-less-dark-${theme})` }}
     >
-      <IonLabel className="average-values-title">Average values</IonLabel>
       <IonCol>
         <div id="inline-block">
           <IonLabel className="average-value">
@@ -209,7 +208,7 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
                 ? lengthOfCycle
                 : "---"}
             </p>
-            <p className="p_style">{t("Cycle")}</p>
+            <p className="p_style">{t("Cycle length")}</p>
           </IonLabel>
         </div>
         <div id="vertical-line" />
@@ -218,7 +217,7 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
             <p className="h_style">
               {averageLengthOfPeriod ? lengthOfPeriod : "---"}
             </p>
-            <p className="p_style">{t("Menstruation")}</p>
+            <p className="p_style">{t("Period length")}</p>
           </IonLabel>
         </div>
       </IonCol>

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -224,7 +224,7 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
       style={{
         marginBottom: "15px",
         borderRadius: "14px",
-        width: "300px",
+        width: "320px",
         height: "90px",
         background: `var(--ion-color-less-dark-${theme})`,
       }}
@@ -249,6 +249,7 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
             <p style={p_style}>{t("Cycle")}</p>
           </IonLabel>
         </div>
+        <div id="vertical-line" />
         <div id="inline-block">
           <IonLabel className="average-value">
             <p style={h_style}>

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -17,6 +17,7 @@ import {
   getLastStartDate,
 } from "../state/CalculationLogics";
 import { CyclesContext, ThemeContext } from "../state/Context";
+import { Cycle } from "../data/ClassCycle";
 import { format } from "../utils/datetime";
 
 import "./TabDetails.css";
@@ -184,9 +185,12 @@ const ListProgress = () => {
   return <>{list}</>;
 };
 
-const TabDetails = () => {
+interface AverageValuesProps {
+  cycles: Cycle[];
+}
+
+const AverageValues = ({ cycles }: AverageValuesProps) => {
   const { t } = useTranslation();
-  const cycles = useContext(CyclesContext).cycles;
   const theme = useContext(ThemeContext).theme;
 
   const averageLengthOfCycle = getAverageLengthOfCycle(cycles);
@@ -216,6 +220,44 @@ const TabDetails = () => {
   };
 
   return (
+    <div
+      id="average-length"
+      style={{
+        marginBottom: "15px",
+        width: "300px",
+        background: `var(--ion-color-less-dark-${theme})`,
+      }}
+    >
+      <IonCol>
+        <div id="inline-block">
+          <IonLabel>
+            <p style={h_style}>
+              {averageLengthOfCycle && cycles.length > 1
+                ? lengthOfCycle
+                : "---"}
+            </p>
+            <p style={p_style}>{t("Cycle")}</p>
+          </IonLabel>
+        </div>
+        <div id="inline-block">
+          <IonLabel>
+            <p style={h_style}>
+              {averageLengthOfPeriod ? lengthOfPeriod : "---"}
+            </p>
+            <p style={p_style}>{t("Menstruation")}</p>
+          </IonLabel>
+        </div>
+      </IonCol>
+    </div>
+  );
+};
+
+const TabDetails = () => {
+  const { t } = useTranslation();
+  const cycles = useContext(CyclesContext).cycles;
+  const theme = useContext(ThemeContext).theme;
+
+  return (
     <IonPage
       style={{ backgroundColor: `var(--ion-color-background-${theme})` }}
     >
@@ -227,42 +269,9 @@ const TabDetails = () => {
           className="ion-padding"
           color={`transparent-${theme}`}
         >
-          <div id="context-size">
+          <div>
             <IonCol>
-              <div
-                id="average-length"
-                style={{
-                  marginBottom: "15px",
-                  background: `var(--ion-color-less-dark-${theme})`,
-                }}
-              >
-                <IonCol>
-                  <div
-                    id="inline-block"
-                    style={{
-                      background: `var(--ion-color-less-dark-${theme})`,
-                    }}
-                  >
-                    <IonLabel style={{ marginBottom: "10px" }}>
-                      <p style={p_style}>{t("Cycle length")}</p>
-                      <p style={h_style}>
-                        {averageLengthOfCycle && cycles.length > 1
-                          ? lengthOfCycle
-                          : "---"}
-                      </p>
-                    </IonLabel>
-                  </div>
-                  <div id="vertical-line" />
-                  <div id="inline-block">
-                    <IonLabel>
-                      <p style={p_style}>{t("Period length")}</p>
-                      <p style={h_style}>
-                        {averageLengthOfPeriod ? lengthOfPeriod : "---"}
-                      </p>
-                    </IonLabel>
-                  </div>
-                </IonCol>
-              </div>
+              <AverageValues cycles={cycles} />
             </IonCol>
             <IonCol>
               {cycles.length > 0 ? (

--- a/src/pages/TabDetails.tsx
+++ b/src/pages/TabDetails.tsx
@@ -195,55 +195,30 @@ const AverageValues = ({ cycles }: AverageValuesProps) => {
     count: averageLengthOfPeriod,
   })}`;
 
-  const p_style = {
-    fontSize: "12px" as const,
-    color: "var(--ion-color-light)" as const,
-    textAlign: "left" as const,
-    marginBottom: "5px" as const,
-  };
-
-  const h_style = {
-    fontSize: "20px" as const,
-    color: "var(--ion-color-light)" as const,
-    textAlign: "left" as const,
-  };
-
   return (
     <div
-      style={{
-        marginBottom: "15px",
-        borderRadius: "15px",
-        height: "90px",
-        background: `var(--ion-color-less-dark-${theme})`,
-      }}
+      id="general-block"
+      style={{ background: `var(--ion-color-less-dark-${theme})` }}
     >
-      <IonLabel
-        className="average-values-title"
-        style={{
-          fontSize: "17px",
-          color: "var(--ion-color-light)",
-        }}
-      >
-        Average values
-      </IonLabel>
+      <IonLabel className="average-values-title">Average values</IonLabel>
       <IonCol>
         <div id="inline-block">
           <IonLabel className="average-value">
-            <p style={h_style}>
+            <p className="h_style">
               {averageLengthOfCycle && cycles.length > 1
                 ? lengthOfCycle
                 : "---"}
             </p>
-            <p style={p_style}>{t("Cycle")}</p>
+            <p className="p_style">{t("Cycle")}</p>
           </IonLabel>
         </div>
         <div id="vertical-line" />
         <div id="inline-block">
           <IonLabel className="average-value">
-            <p style={h_style}>
+            <p className="h_style">
               {averageLengthOfPeriod ? lengthOfPeriod : "---"}
             </p>
-            <p style={p_style}>{t("Menstruation")}</p>
+            <p className="p_style">{t("Menstruation")}</p>
           </IonLabel>
         </div>
       </IonCol>
@@ -268,29 +243,25 @@ const TabDetails = () => {
           className="ion-padding"
           color={`transparent-${theme}`}
         >
-          <div>
-            <IonCol>
-              <AverageValues cycles={cycles} />
-            </IonCol>
-            <IonCol>
-              <div
-                id="progress-block"
-                style={{ background: `var(--ion-color-calendar-${theme})` }}
-              >
-                {cycles.length > 0 ? (
-                  <IonList>
-                    <CurrentCycle />
-                    {cycles.length > 1 && <ListProgress />}
-                  </IonList>
-                ) : (
-                  <div id="progress-block">
-                    <p style={{ fontSize: "13px" }}>
-                      {t("You haven't marked any periods yet")}
-                    </p>
-                  </div>
-                )}
-              </div>
-            </IonCol>
+          <div id="width-details-screen">
+            <AverageValues cycles={cycles} />
+            <div
+              id="progress-block"
+              style={{ background: `var(--ion-color-calendar-${theme})` }}
+            >
+              {cycles.length > 0 ? (
+                <IonList>
+                  <CurrentCycle />
+                  {cycles.length > 1 && <ListProgress />}
+                </IonList>
+              ) : (
+                <div id="progress-block">
+                  <p style={{ fontSize: "13px" }}>
+                    {t("You haven't marked any periods yet")}
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
         </IonContent>
       </div>


### PR DESCRIPTION
Closed #173 

I changed the design of the Details tab.
This is the old one:
![image](https://github.com/IraSoro/peri/assets/52165881/6f583fb3-a9b3-41a7-a837-7db601195c02)
This is the new one:
![image](https://github.com/IraSoro/peri/assets/52165881/c58bff70-f5cd-4d9d-91df-a40900a72e1a)

Now there is a problem that the code is written a little unclear in defining the color for the theme. Right now we only have light and dark ones. I know that Ionic has the ability to specify colors for the dark and light version. I created a [task](https://github.com/IraSoro/peri/issues/245) for this.