### PR TITLE
Edit Info Modal design

### DIFF
--- a/src/modals/InfoModal.css
+++ b/src/modals/InfoModal.css
@@ -10,14 +10,16 @@ p.info-title-basic {
   font-size: 25px;
   margin-bottom: 24px;
   color: var(--ion-color-dark-basic);
-
-  text-align: center;
 }
 
-p.info-item-basic {
+li.info-item-basic {
   font-size: 16px;
   margin-bottom: 20px;
   color: var(--ion-color-text-basic);
+}
+
+li.info-item-basic::marker {
+  color: var(--ion-color-dark-basic);
 }
 
 span.info-item-basic {
@@ -31,14 +33,16 @@ p.info-title-dark {
   font-size: 25px;
   margin-bottom: 24px;
   color: var(--ion-color-dark-dark);
-
-  text-align: center;
 }
 
-p.info-item-dark {
+li.info-item-dark {
   font-size: 16px;
   margin-bottom: 20px;
   color: var(--ion-color-text-dark);
+}
+
+li.info-item-dark::marker {
+  color: var(--ion-color-dark-dark);
 }
 
 span.info-item-dark {

--- a/src/modals/InfoModal.css
+++ b/src/modals/InfoModal.css
@@ -1,0 +1,47 @@
+div.info-screen {
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* basic */
+p.info-title-basic {
+  font-weight: bold;
+  font-size: 25px;
+  margin-bottom: 24px;
+  color: var(--ion-color-dark-basic);
+
+  text-align: center;
+}
+
+p.info-item-basic {
+  font-size: 16px;
+  margin-bottom: 20px;
+  color: var(--ion-color-text-basic);
+}
+
+span.info-item-basic {
+  color: var(--ion-color-less-dark-basic);
+  font-weight: bold;
+}
+
+/* dark */
+p.info-title-dark {
+  font-weight: bold;
+  font-size: 25px;
+  margin-bottom: 24px;
+  color: var(--ion-color-dark-dark);
+
+  text-align: center;
+}
+
+p.info-item-dark {
+  font-size: 16px;
+  margin-bottom: 20px;
+  color: var(--ion-color-text-dark);
+}
+
+span.info-item-dark {
+  color: var(--ion-color-less-dark-dark);
+  font-weight: bold;
+}

--- a/src/modals/InfoModal.tsx
+++ b/src/modals/InfoModal.tsx
@@ -11,6 +11,8 @@ import {
   getPregnancyChance,
 } from "../state/CalculationLogics";
 
+import "./InfoModal.css";
+
 interface PropsInfoModal {
   isOpen: boolean;
   setIsOpen: (newIsOpen: boolean) => void;
@@ -38,27 +40,34 @@ const InfoModal = (props: PropsInfoModal) => {
         className="ion-padding"
         color={`transparent-${theme}`}
       >
-        <p
+        <div
           style={{
-            fontWeight: "bold",
-            fontSize: "25px",
-            color: `var(--ion-color-dark-${theme})`,
-            marginBottom: "24px",
+            maxWidth: "400px",
+            marginLeft: "auto",
+            marginRight: "auto",
           }}
         >
-          {`${t("Days", {
-            postProcess: "interval",
-            count: 1, // NOTE: to indicate which day is in the account, you need to write the day as if in the singular
-          })} `}
-          {cycles.length === 1 ? (
-            currentDay
-          ) : (
-            <>
-              {currentDay}/{lengthOfCycle}
-            </>
-          )}
-        </p>
-        <ul>
+          <p
+            className="info-title"
+            style={{
+              fontWeight: "bold",
+              fontSize: "25px",
+              color: `var(--ion-color-dark-${theme})`,
+              marginBottom: "24px",
+            }}
+          >
+            {`${t("Days", {
+              postProcess: "interval",
+              count: 1, // NOTE: to indicate which day is in the account, you need to write the day as if in the singular
+            })} `}
+            {cycles.length === 1 ? (
+              currentDay
+            ) : (
+              <>
+                {currentDay}/{lengthOfCycle}
+              </>
+            )}
+          </p>
           <li
             style={{
               fontSize: "16px",
@@ -110,18 +119,17 @@ const InfoModal = (props: PropsInfoModal) => {
             </span>
             <span> {t("chance of getting pregnant")}</span>
           </li>
-        </ul>
-        <p
-          style={{
-            fontWeight: "bold",
-            fontSize: "25px",
-            color: `var(--ion-color-dark-${theme})`,
-            marginBottom: "24px",
-          }}
-        >
-          {t("Frequent symptoms")}
-        </p>
-        <ul>
+          <p
+            className="info-title"
+            style={{
+              fontWeight: "bold",
+              fontSize: "25px",
+              color: `var(--ion-color-dark-${theme})`,
+              marginBottom: "24px",
+            }}
+          >
+            {t("Frequent symptoms")}
+          </p>
           {phase.symptoms.map((item, idx) => (
             <li
               style={{
@@ -134,16 +142,16 @@ const InfoModal = (props: PropsInfoModal) => {
               {item}
             </li>
           ))}
-        </ul>
-        <IonCol>
-          <IonButton
-            className="main"
-            color={`dark-${theme}`}
-            onClick={() => props.setIsOpen(false)}
-          >
-            OK
-          </IonButton>
-        </IonCol>
+          <IonCol>
+            <IonButton
+              className="main"
+              color={`dark-${theme}`}
+              onClick={() => props.setIsOpen(false)}
+            >
+              OK
+            </IonButton>
+          </IonCol>
+        </div>
       </IonContent>
     </IonModal>
   );

--- a/src/modals/InfoModal.tsx
+++ b/src/modals/InfoModal.tsx
@@ -54,29 +54,33 @@ const InfoModal = (props: PropsInfoModal) => {
               </>
             )}
           </p>
-          <p className={`info-item-${theme}`}>
-            <span className={`info-item-${theme}`}>{phase.title}</span>
-            <span> {t("is current phase of cycle")}</span>
-          </p>
-          <p className={`info-item-${theme}`}>
-            <span>{t("Ovulation")}</span>
-            <span className={`info-item-${theme}`}>
-              {` ${ovulationStatus}`}
-            </span>
-          </p>
-          <p className={`info-item-${theme}`}>
-            <span className={`info-item-${theme}`}>{pregnancyChance}</span>
-            <span> {t("chance of getting pregnant")}</span>
-          </p>
+          <ul>
+            <li className={`info-item-${theme}`}>
+              <span className={`info-item-${theme}`}>{phase.title}</span>
+              <span> {t("is current phase of cycle")}</span>
+            </li>
+            <li className={`info-item-${theme}`}>
+              <span>{t("Ovulation")}</span>
+              <span className={`info-item-${theme}`}>
+                {` ${ovulationStatus}`}
+              </span>
+            </li>
+            <li className={`info-item-${theme}`}>
+              <span className={`info-item-${theme}`}>{pregnancyChance}</span>
+              <span> {t("chance of getting pregnant")}</span>
+            </li>
+          </ul>
           <p className={`info-title-${theme}`}>{t("Frequent symptoms")}</p>
-          {phase.symptoms.map((item, idx) => (
-            <p
-              className={`info-item-${theme}`}
-              key={idx}
-            >
-              {item}
-            </p>
-          ))}
+          <ul>
+            {phase.symptoms.map((item, idx) => (
+              <li
+                className={`info-item-${theme}`}
+                key={idx}
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
           <IonCol>
             <IonButton
               className="main"

--- a/src/modals/InfoModal.tsx
+++ b/src/modals/InfoModal.tsx
@@ -68,7 +68,7 @@ const InfoModal = (props: PropsInfoModal) => {
               </>
             )}
           </p>
-          <li
+          <p
             style={{
               fontSize: "16px",
               color: `var(--ion-color-text-${theme})`,
@@ -84,8 +84,8 @@ const InfoModal = (props: PropsInfoModal) => {
               {phase.title}
             </span>
             <span> {t("is current phase of cycle")}</span>
-          </li>
-          <li
+          </p>
+          <p
             style={{
               fontSize: "16px",
               color: `var(--ion-color-text-${theme})`,
@@ -101,8 +101,8 @@ const InfoModal = (props: PropsInfoModal) => {
             >
               {` ${ovulationStatus}`}
             </span>
-          </li>
-          <li
+          </p>
+          <p
             style={{
               fontSize: "16px",
               color: `var(--ion-color-text-${theme})`,
@@ -118,7 +118,7 @@ const InfoModal = (props: PropsInfoModal) => {
               {pregnancyChance}
             </span>
             <span> {t("chance of getting pregnant")}</span>
-          </li>
+          </p>
           <p
             className="info-title"
             style={{
@@ -131,7 +131,7 @@ const InfoModal = (props: PropsInfoModal) => {
             {t("Frequent symptoms")}
           </p>
           {phase.symptoms.map((item, idx) => (
-            <li
+            <p
               style={{
                 fontSize: "16px",
                 color: `var(--ion-color-text-${theme})`,
@@ -140,7 +140,7 @@ const InfoModal = (props: PropsInfoModal) => {
               key={idx}
             >
               {item}
-            </li>
+            </p>
           ))}
           <IonCol>
             <IonButton

--- a/src/modals/InfoModal.tsx
+++ b/src/modals/InfoModal.tsx
@@ -40,22 +40,8 @@ const InfoModal = (props: PropsInfoModal) => {
         className="ion-padding"
         color={`transparent-${theme}`}
       >
-        <div
-          style={{
-            maxWidth: "400px",
-            marginLeft: "auto",
-            marginRight: "auto",
-          }}
-        >
-          <p
-            className="info-title"
-            style={{
-              fontWeight: "bold",
-              fontSize: "25px",
-              color: `var(--ion-color-dark-${theme})`,
-              marginBottom: "24px",
-            }}
-          >
+        <div className="info-screen">
+          <p className={`info-title-${theme}`}>
             {`${t("Days", {
               postProcess: "interval",
               count: 1, // NOTE: to indicate which day is in the account, you need to write the day as if in the singular
@@ -68,75 +54,24 @@ const InfoModal = (props: PropsInfoModal) => {
               </>
             )}
           </p>
-          <p
-            style={{
-              fontSize: "16px",
-              color: `var(--ion-color-text-${theme})`,
-              marginBottom: "20px",
-            }}
-          >
-            <span
-              style={{
-                color: `var(--ion-color-less-dark-${theme})`,
-                fontWeight: "bold",
-              }}
-            >
-              {phase.title}
-            </span>
+          <p className={`info-item-${theme}`}>
+            <span className={`info-item-${theme}`}>{phase.title}</span>
             <span> {t("is current phase of cycle")}</span>
           </p>
-          <p
-            style={{
-              fontSize: "16px",
-              color: `var(--ion-color-text-${theme})`,
-              marginBottom: "20px",
-            }}
-          >
+          <p className={`info-item-${theme}`}>
             <span>{t("Ovulation")}</span>
-            <span
-              style={{
-                color: `var(--ion-color-less-dark-${theme})`,
-                fontWeight: "bold",
-              }}
-            >
+            <span className={`info-item-${theme}`}>
               {` ${ovulationStatus}`}
             </span>
           </p>
-          <p
-            style={{
-              fontSize: "16px",
-              color: `var(--ion-color-text-${theme})`,
-              marginBottom: "20px",
-            }}
-          >
-            <span
-              style={{
-                color: `var(--ion-color-less-dark-${theme})`,
-                fontWeight: "bold",
-              }}
-            >
-              {pregnancyChance}
-            </span>
+          <p className={`info-item-${theme}`}>
+            <span className={`info-item-${theme}`}>{pregnancyChance}</span>
             <span> {t("chance of getting pregnant")}</span>
           </p>
-          <p
-            className="info-title"
-            style={{
-              fontWeight: "bold",
-              fontSize: "25px",
-              color: `var(--ion-color-dark-${theme})`,
-              marginBottom: "24px",
-            }}
-          >
-            {t("Frequent symptoms")}
-          </p>
+          <p className={`info-title-${theme}`}>{t("Frequent symptoms")}</p>
           {phase.symptoms.map((item, idx) => (
             <p
-              style={{
-                fontSize: "16px",
-                color: `var(--ion-color-text-${theme})`,
-                marginBottom: "20px",
-              }}
+              className={`info-item-${theme}`}
               key={idx}
             >
               {item}


### PR DESCRIPTION
Closed #252 

I corrected the design of the Info Modal a little. I didn't like the dots before the elements. It looked like a document.
This is a old design:
![image](https://github.com/IraSoro/peri/assets/52165881/d29c1134-c59c-4e79-8438-a35cfc07cfa5)

This is the new one:
![image](https://github.com/IraSoro/peri/assets/52165881/81de8723-adb6-4082-a91d-4a139e20b49e)

I also moved some styles to the .css file because they were often duplicated.