### PR TITLE
Fix incorrect day shift after cycle edit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,8 +87,9 @@ const App = (props: AppProps) => {
   );
 
   function updateCycles(newCycles: Cycle[]) {
-    setCycles(newCycles.slice(0, maxOfCycles));
-    storage.set.cycles(newCycles).catch((err) => console.error(err));
+    const slicedCycles = newCycles.slice(0, maxOfCycles);
+    setCycles(slicedCycles);
+    storage.set.cycles(slicedCycles).catch((err) => console.error(err));
   }
 
   function updateTheme(newTheme: string) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import "./theme/variables.css";
 import { storage } from "./data/Storage";
 
 import type { Cycle } from "./data/ClassCycle";
+import { maxOfCycles } from "./state/CalculationLogics";
 import { CyclesContext, ThemeContext } from "./state/Context";
 import { Menu } from "./modals/Menu";
 import { isNewVersionAvailable } from "./data/AppVersion";
@@ -86,7 +87,6 @@ const App = (props: AppProps) => {
   );
 
   function updateCycles(newCycles: Cycle[]) {
-    const maxOfCycles = 7;
     setCycles(newCycles.slice(0, maxOfCycles));
     storage.set.cycles(newCycles).catch((err) => console.error(err));
   }

--- a/src/data/Storage.ts
+++ b/src/data/Storage.ts
@@ -79,17 +79,17 @@ export const storage = {
 //       for use just uncomment one of the following lines:
 
 // _emptyArrayOfCycles().catch((err) => console.error(err));
-// _todayPeriod(7).catch((err) => console.error(err));
-// _todayOvulation(7).catch((err) => console.error(err));
-// _tomorrowOvulation(7).catch((err) => console.error(err));
-// _menstrualPhase(7).catch((err) => console.error(err));
-// _follicularPhase(7).catch((err) => console.error(err));
-// _lutealPhase(7).catch((err) => console.error(err));
-// _delayOfCycle(7).catch((err) => console.error(err));
-// _randomMenstrualPhase(7).catch((err) => console.error(err));
-// _randomFollicularPhase(7).catch((err) => console.error(err));
-// _randomLutealPhase(7).catch((err) => console.error(err));
-// _randomDelayOfCycle(7).catch((err) => console.error(err));
+// _todayPeriod(8).catch((err) => console.error(err));
+// _todayOvulation(8).catch((err) => console.error(err));
+// _tomorrowOvulation(8).catch((err) => console.error(err));
+// _menstrualPhase(8).catch((err) => console.error(err));
+// _follicularPhase(8).catch((err) => console.error(err));
+// _lutealPhase(8).catch((err) => console.error(err));
+// _delayOfCycle(8).catch((err) => console.error(err));
+// _randomMenstrualPhase(8).catch((err) => console.error(err));
+// _randomFollicularPhase(8).catch((err) => console.error(err));
+// _randomLutealPhase(8).catch((err) => console.error(err));
+// _randomDelayOfCycle(8).catch((err) => console.error(err));
 
 function _emptyArrayOfCycles(): Promise<void> {
   return storageImpl.remove("cycles") as Promise<void>;

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -11,7 +11,7 @@ import { Cycle } from "../data/ClassCycle";
 import { format } from "../utils/datetime";
 
 export const maxOfCycles = 8;
-const maxDisplayedCycles = 5;
+const maxDisplayedCycles = 6;
 
 export function getLastStartDate(cycles: Cycle[]) {
   if (cycles.length === 0) {
@@ -242,7 +242,7 @@ export function getAverageLengthOfCycle(cycles: Cycle[]) {
     0,
   );
 
-  return Math.round(sum / length - 1); //NOTE: We subtract 1 because the length of the current cycle (with index 0) is 0 and we don't need to take it into account in the calculation.
+  return Math.round(sum / (length - 1)); //NOTE: We subtract 1 because the length of the current cycle (with index 0) is 0 and we don't need to take it into account in the calculation.
 }
 
 export function getAverageLengthOfPeriod(cycles: Cycle[]) {

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -11,6 +11,7 @@ import { Cycle } from "../data/ClassCycle";
 import { format } from "../utils/datetime";
 
 export const maxOfCycles = 8;
+const maxDisplayedCycles = 5;
 
 export function getLastStartDate(cycles: Cycle[]) {
   if (cycles.length === 0) {
@@ -229,41 +230,35 @@ export function getPhase(cycles: Cycle[]) {
 }
 
 export function getAverageLengthOfCycle(cycles: Cycle[]) {
-  if (cycles.length === 0) {
-    return 0;
+  const displayedCycles = cycles.slice(0, maxDisplayedCycles);
+  const length = displayedCycles.length;
+
+  if (length <= 1) {
+    return length === 0 ? 0 : displayedCycles[0].cycleLength; // NOTE: If there is only one cycle in history (the current one), then its length is at least 28 or more
   }
 
-  if (cycles.length === 1) {
-    return cycles[0].cycleLength;
-  }
+  const sum = displayedCycles.reduce(
+    (prev, current) => prev + current.cycleLength,
+    0,
+  );
 
-  const sum = cycles.reduce((prev, current, idx) => {
-    if (idx > 0) {
-      return prev + current.cycleLength;
-    }
-    return 0;
-  }, 0);
-
-  return Math.round(sum / (cycles.length - 1));
+  return Math.round(sum / length - 1); //NOTE: We subtract 1 because the length of the current cycle (with index 0) is 0 and we don't need to take it into account in the calculation.
 }
 
 export function getAverageLengthOfPeriod(cycles: Cycle[]) {
-  if (cycles.length === 0) {
-    return 0;
+  const displayedCycles = cycles.slice(0, maxDisplayedCycles);
+  const length = displayedCycles.length;
+
+  if (length <= 1) {
+    return length === 0 ? 0 : displayedCycles[0].periodLength;
   }
 
-  if (cycles.length === 1) {
-    return cycles[0].periodLength;
-  }
+  const sum = displayedCycles.reduce(
+    (prev, current) => prev + current.periodLength,
+    0,
+  );
 
-  const sum = cycles.reduce((prev, current, idx) => {
-    if (idx > 0) {
-      return prev + current.periodLength;
-    }
-    return 0;
-  }, 0);
-
-  return Math.round(sum / (cycles.length - 1));
+  return Math.round(sum / length);
 }
 
 export function getNewCyclesHistory(periodDays: string[]) {

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -10,6 +10,8 @@ import {
 import { Cycle } from "../data/ClassCycle";
 import { format } from "../utils/datetime";
 
+export const maxOfCycles = 8;
+
 export function getLastStartDate(cycles: Cycle[]) {
   if (cycles.length === 0) {
     return "";

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -234,7 +234,8 @@ export function getAverageLengthOfCycle(cycles: Cycle[]) {
   const length = displayedCycles.length;
 
   if (length <= 1) {
-    return length === 0 ? 0 : displayedCycles[0].cycleLength; // NOTE: If there is only one cycle in history (the current one), then its length is at least 28 or more
+    // NOTE: If there is only one cycle in history (the current one), then its length is at least 28 or more
+    return length === 0 ? 0 : displayedCycles[0].cycleLength;
   }
 
   const sum = displayedCycles.reduce(
@@ -242,7 +243,8 @@ export function getAverageLengthOfCycle(cycles: Cycle[]) {
     0,
   );
 
-  return Math.round(sum / (length - 1)); //NOTE: We subtract 1 because the length of the current cycle is 0 (i.e. cycles[0].cycleLength = 0) and we don't need to take it into account in the calculation.
+  //NOTE: We subtract 1 because the length of the current cycle is 0 (i.e. cycles[0].cycleLength = 0) and we don't need to take it into account in the calculation.
+  return Math.round(sum / (length - 1));
 }
 
 export function getAverageLengthOfPeriod(cycles: Cycle[]) {

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -306,9 +306,10 @@ export function getNewCyclesHistory(periodDays: string[]) {
 }
 
 export function getPeriodDays(cycles: Cycle[]) {
+  const maxCountCycles = cycles.slice(0, maxDisplayedCycles);
   const periodDays: string[] = [];
 
-  for (const cycle of cycles) {
+  for (const cycle of maxCountCycles) {
     const startOfCycle = startOfDay(new Date(cycle.startDate));
 
     for (let i = 0; i < cycle.periodLength; i++) {

--- a/src/state/CalculationLogics.ts
+++ b/src/state/CalculationLogics.ts
@@ -242,7 +242,7 @@ export function getAverageLengthOfCycle(cycles: Cycle[]) {
     0,
   );
 
-  return Math.round(sum / (length - 1)); //NOTE: We subtract 1 because the length of the current cycle (with index 0) is 0 and we don't need to take it into account in the calculation.
+  return Math.round(sum / (length - 1)); //NOTE: We subtract 1 because the length of the current cycle is 0 (i.e. cycles[0].cycleLength = 0) and we don't need to take it into account in the calculation.
 }
 
 export function getAverageLengthOfPeriod(cycles: Cycle[]) {

--- a/src/tests/CalculationLogic.test.ts
+++ b/src/tests/CalculationLogic.test.ts
@@ -206,6 +206,7 @@ describe("getDayOfCycle", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getDayOfCycle(cycles)).toEqual(14);
   });
@@ -399,7 +400,6 @@ describe("getDaysBeforePeriod", () => {
         startDate: subDays(date, 28).toString(),
       },
     ];
-    cycles[0].cycleLength = 0;
 
     expect(getDaysBeforePeriod(cycles)).toEqual({
       title: i18n.t("Period is"),
@@ -493,6 +493,7 @@ describe("getDaysBeforePeriod", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getDaysBeforePeriod(cycles)).toEqual({
       title: i18n.t("Period"),
@@ -825,6 +826,7 @@ describe("getActiveDates", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     const dateCheck = addDays(startOfDay(new Date(cycles[0].startDate)), 1);
     expect(getActiveDates(dateCheck, cycles)).toEqual(true);
@@ -845,6 +847,7 @@ describe("getActiveDates", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     const dateCheck = addDays(startOfDay(new Date(cycles[0].startDate)), 7);
     expect(getActiveDates(dateCheck, cycles)).toEqual(false);
@@ -865,6 +868,7 @@ describe("getActiveDates", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     const dateCheck = addDays(startOfDay(new Date(cycles[0].startDate)), 7);
     expect(getActiveDates(dateCheck, cycles)).toEqual(true);
@@ -885,6 +889,7 @@ describe("getActiveDates", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     const dateCheck = addDays(startOfDay(new Date(cycles[0].startDate)), 15);
     expect(getActiveDates(dateCheck, cycles)).toEqual(false);
@@ -905,6 +910,7 @@ describe("getActiveDates", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     const dateCheck = addDays(startOfDay(new Date(cycles[0].startDate)), 10);
     expect(getActiveDates(dateCheck, cycles)).toEqual(true);
@@ -925,6 +931,7 @@ describe("getActiveDates", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     const dateCheck = addDays(startOfDay(new Date(cycles[0].startDate)), 40);
     expect(getActiveDates(dateCheck, cycles)).toEqual(false);
@@ -960,6 +967,7 @@ describe("getPastFuturePeriodDays", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     const periodDates = getPeriodDays(cycles).map((isoDateString) => {
       return parseISO(isoDateString).toString();
@@ -988,6 +996,7 @@ describe("getPastFuturePeriodDays", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     const periodDates = getPeriodDays(cycles).map((isoDateString) => {
       return parseISO(isoDateString).toString();
@@ -1023,6 +1032,7 @@ describe("getLastStartDate", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getLastStartDate(cycles)).toEqual(cycles[0].startDate);
   });
@@ -1048,6 +1058,7 @@ describe("getLengthOfLastPeriod", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getLengthOfLastPeriod(cycles)).toEqual(cycles[0].periodLength);
   });

--- a/src/tests/CalculationLogic.test.ts
+++ b/src/tests/CalculationLogic.test.ts
@@ -49,6 +49,8 @@ describe("getOvulationStatus", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
+
     expect(getOvulationStatus(cycles)).toEqual(
       `${i18n.t("in")} 9 ${i18n.t("Days", {
         postProcess: "interval",
@@ -72,6 +74,8 @@ describe("getOvulationStatus", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
+
     expect(getOvulationStatus(cycles)).toEqual("tomorrow");
   });
 
@@ -90,6 +94,8 @@ describe("getOvulationStatus", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
+
     expect(getOvulationStatus(cycles)).toEqual("today");
   });
 
@@ -108,6 +114,8 @@ describe("getOvulationStatus", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
+
     expect(getOvulationStatus(cycles)).toEqual("possible");
   });
 
@@ -126,6 +134,8 @@ describe("getOvulationStatus", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
+
     expect(getOvulationStatus(cycles)).toEqual("finished");
   });
 });
@@ -150,6 +160,8 @@ describe("getPregnancyChance", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
+
     expect(getPregnancyChance(cycles)).toEqual("High");
   });
 
@@ -167,6 +179,8 @@ describe("getPregnancyChance", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
+
     expect(getPregnancyChance(cycles)).toEqual("Low");
   });
 });
@@ -311,6 +325,7 @@ describe("getDaysBeforePeriod", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getDaysBeforePeriod(cycles)).toEqual({
       title: i18n.t("Period in"),
@@ -336,6 +351,7 @@ describe("getDaysBeforePeriod", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getDaysBeforePeriod(cycles)).toEqual({
       title: i18n.t("Period in"),
@@ -362,6 +378,7 @@ describe("getDaysBeforePeriod", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getDaysBeforePeriod(cycles)).toEqual({
       title: i18n.t("Period"),
@@ -382,6 +399,7 @@ describe("getDaysBeforePeriod", () => {
         startDate: subDays(date, 28).toString(),
       },
     ];
+    cycles[0].cycleLength = 0;
 
     expect(getDaysBeforePeriod(cycles)).toEqual({
       title: i18n.t("Period is"),
@@ -404,6 +422,7 @@ describe("getDaysBeforePeriod", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getDaysBeforePeriod(cycles)).toEqual({
       title: i18n.t("Delay"),
@@ -429,6 +448,7 @@ describe("getDaysBeforePeriod", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getDaysBeforePeriod(cycles)).toEqual({
       title: i18n.t("Delay"),
@@ -558,6 +578,7 @@ describe("getPhase", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getPhase(cycles)).toEqual(phases.menstrual);
   });
@@ -577,6 +598,7 @@ describe("getPhase", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getPhase(cycles)).toEqual(phases.follicular);
   });
@@ -596,6 +618,7 @@ describe("getPhase", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getPhase(cycles)).toEqual(phases.ovulation);
   });
@@ -615,6 +638,7 @@ describe("getPhase", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     expect(getPhase(cycles)).toEqual(phases.luteal);
   });
@@ -1051,6 +1075,7 @@ describe("getForecastPeriodDays", () => {
         startDate: date.toString(),
       });
     }
+    cycles[0].cycleLength = 0;
 
     const forecastDays = [];
     let nextCycleStart = addDays(startOfDay(new Date(cycles[0].startDate)), 28);


### PR DESCRIPTION
Closed #258 

I found the reason why the shift is happening. We have a maximum number of cycles in the storage. So if we already have the maximum number of cycles stored, then when adding a new one, one is deleted. If we return everything after this, then one of the cycles has already been deleted, so new average values ​​are recalculated. And since the average values ​​have changed, the forecast has changed.

I solved this problem like this.
1. I increased the maximum number of stored cycles to 8.
2. Now the average is calculated only from those cycles that are displayed in the application (6 of them). Therefore, 2 more will be spare, we do not take them into account in the calculations, but they are stored for these cases as in these bug.

I also found another bug. My `peri.json` file has more than 7 cycles stored, I fixed it. I didn't before slice the cycles that we send to storage.