### PR TITLE
Fix import config alert

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,9 +94,6 @@ const App = (props: AppProps) => {
   }
 
   function updateTheme(newTheme: string) {
-    if (newTheme === "dark (beta)") {
-      newTheme = "dark";
-    }
     if (newTheme === "light") {
       newTheme = "basic";
     }

--- a/src/modals/Menu.tsx
+++ b/src/modals/Menu.tsx
@@ -152,7 +152,7 @@ const Importer = () => {
     await changeTranslation(config.language);
     await confirmAlert({
       header: t("Configuration has been imported"),
-      cssClass: "header-color",
+      cssClass: `${theme}`,
       buttons: [
         {
           text: "OK",

--- a/src/modals/Menu.tsx
+++ b/src/modals/Menu.tsx
@@ -92,7 +92,7 @@ const ThemeSwitcher = () => {
   const { theme, updateTheme } = useContext(ThemeContext);
 
   const themesList = [];
-  for (const item of ["light", "dark (beta)"]) {
+  for (const item of ["light", "dark"]) {
     themesList.push(
       <IonSelectOption
         key={item}
@@ -113,9 +113,7 @@ const ThemeSwitcher = () => {
 
       <IonSelect
         className={theme}
-        value={
-          theme === "dark" ? "dark (beta)" : theme === "basic" ? "light" : theme
-        }
+        value={theme === "basic" ? "light" : theme}
         interface="popover"
         justify="space-between"
         interfaceOptions={{

--- a/src/modals/Menu.tsx
+++ b/src/modals/Menu.tsx
@@ -15,7 +15,7 @@ import {
   cloudDownloadOutline,
   cloudUploadOutline,
   globeOutline,
-  colorFilterOutline,
+  colorFillOutline,
 } from "ionicons/icons";
 import { useTranslation } from "react-i18next";
 import { storage } from "../data/Storage";
@@ -107,7 +107,7 @@ const ThemeSwitcher = () => {
     <IonItem>
       <IonIcon
         slot="start"
-        icon={colorFilterOutline}
+        icon={colorFillOutline}
         color={`text-${theme}`}
       />
 


### PR DESCRIPTION
Closed #270 

I fixed this problem.
But it will work only if: you already have a dark theme, you import a config with a dark theme, the alert is displayed with a dark theme. But if you import a config with a light theme, the alert will be displayed with a dark theme this time.

The dark alert looks like this:
![image](https://github.com/user-attachments/assets/0a12748c-49d0-450b-a447-f6a246764b1e)

I also removed the word `beta` from the dark theme selection.

And changed icon for theme select. The new icon looks like this
![image](https://github.com/user-attachments/assets/2f59435a-dfed-49a2-8063-76cc47c8629d)
