### PR TITLE
Fixed tab with id warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -200,6 +200,7 @@ const App = (props: AppProps) => {
                 >
                   <IonTabButton
                     tab="menu"
+                    href="#"
                     style={{
                       background: `var(--ion-color-transparent-${theme})`,
                       border: `var(--ion-color-transparent-${theme})`,


### PR DESCRIPTION
Closes #322 

I set `href="#"` placeholder in the `IonTabButton` element to explicitly tell `react-router` that this tab should't redirect to any tab within the SPA