### PR TITLE
Added license files for project and logo

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,11 @@
+Copyright (c) 2025 Irina Sorokina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+Some image files within this repository are copyrighted. For more information, please refer to the LICENSE.txt file located in the directory.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name "peri" and "Peri Logo" shall not be used in advertising or otherwise to promote the sale, use, or any other dealings in this Software without prior written authorization from Irina Sorokina.

--- a/LOGO_LICENSE.txt
+++ b/LOGO_LICENSE.txt
@@ -3,4 +3,4 @@ Copyright (c) 2025 Irina Sorokina
 
 The "Peri Logo" is protected by copyright. Unauthorized use, reproduction, or distribution of the logo is prohibited without prior written authorization from the copyright holder, Irina Sorokina.
 
-For inquiries regarding the use of the "Peri Logo," please contact irasoro2000@gmail.com.
+For inquiries regarding the use of the "Peri Logo" please contact irasoro2000@gmail.com.

--- a/LOGO_LICENSE.txt
+++ b/LOGO_LICENSE.txt
@@ -1,0 +1,6 @@
+Peri Logo
+Copyright (c) 2025 Irina Sorokina
+
+The "Peri Logo" is protected by copyright. Unauthorized use, reproduction, or distribution of the logo is prohibited without prior written authorization from the copyright holder, Irina Sorokina.
+
+For inquiries regarding the use of the "Peri Logo," please contact irasoro2000@gmail.com.

--- a/public/assets/icon/LICENSE.txt
+++ b/public/assets/icon/LICENSE.txt
@@ -3,4 +3,4 @@ Copyright (c) 2025 Irina Sorokina
 
 The "Peri Logo" is protected by copyright. Unauthorized use, reproduction, or distribution of the logo is prohibited without prior written authorization from the copyright holder, Irina Sorokina.
 
-For inquiries regarding the use of the "Peri Logo," please contact irasoro2000@gmail.com.
+For inquiries regarding the use of the "Peri Logo" please contact irasoro2000@gmail.com.

--- a/public/assets/icon/LICENSE.txt
+++ b/public/assets/icon/LICENSE.txt
@@ -1,0 +1,6 @@
+Peri Logo
+Copyright (c) 2025 Irina Sorokina
+
+The "Peri Logo" is protected by copyright. Unauthorized use, reproduction, or distribution of the logo is prohibited without prior written authorization from the copyright holder, Irina Sorokina.
+
+For inquiries regarding the use of the "Peri Logo," please contact irasoro2000@gmail.com.


### PR DESCRIPTION
Closes #340

I added modified MIT license described in the `LICENSE.txt`. This license is inspired by X11 MIT (more info here https://en.wikipedia.org/wiki/MIT_License). I added additional information about peri name and logo limitations. Also I added `LICENSE.txt` and `LOGO_LICENSE.txt` (duplicate) to show that peri logo is copyrighted