### PR TITLE
Fix top position on the Info Modal

### DIFF
--- a/src/modals/InfoModal.css
+++ b/src/modals/InfoModal.css
@@ -2,6 +2,7 @@ div.info-screen {
   max-width: 400px;
   margin-left: auto;
   margin-right: auto;
+  padding: env(safe-area-inset-top) 16px 0 16px
 }
 
 /* basic */

--- a/src/modals/InfoModal.css
+++ b/src/modals/InfoModal.css
@@ -2,7 +2,7 @@ div.info-screen {
   max-width: 400px;
   margin-left: auto;
   margin-right: auto;
-  padding: env(safe-area-inset-top) 16px 0 16px
+  padding: env(safe-area-inset-top) 16px 0 16px;
 }
 
 /* basic */

--- a/src/modals/InfoModal.tsx
+++ b/src/modals/InfoModal.tsx
@@ -47,9 +47,7 @@ const InfoModal = (props: PropsInfoModal) => {
       backdropDismiss={false}
       isOpen={props.isOpen}
     >
-      <IonContent
-        color={`transparent-${theme}`}
-      >
+      <IonContent color={`transparent-${theme}`}>
         <div className="info-screen">
           <p className={`info-title-${theme}`}>
             {`${t("Days", {

--- a/src/modals/InfoModal.tsx
+++ b/src/modals/InfoModal.tsx
@@ -48,7 +48,6 @@ const InfoModal = (props: PropsInfoModal) => {
       isOpen={props.isOpen}
     >
       <IonContent
-        className="ion-padding"
         color={`transparent-${theme}`}
       >
         <div className="info-screen">


### PR DESCRIPTION
Closed #390 

After the update of last caoacitor version, a bug like this appeared in the Menu https://github.com/ionic-team/capacitor/pull/7871. I fixed it: added [env(safe-area-inset-top)](https://developer.mozilla.org/en-US/docs/Web/CSS/env) padding