### PR TITLE
Fix incorrect Markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Our application supports the following languages:
 - Tamil (தமிழ்)
 - Vietnamese (Tiếng Việt)
 
-You can find the translations files in [this]((https://github.com/IraSoro/peri/tree/master/src/utils/translations)) folder.
+You can find the translations files in [this](https://github.com/IraSoro/peri/tree/master/src/utils/translations) folder.
 
 ### How to build
 
@@ -107,3 +107,4 @@ You can find a description of the logic and algorithms that are used in the appl
 ### Thanks for noticing our project
 
 [![MadeWithReactJs.com shield](https://madewithreactjs.com/storage/repo-shields/5322-shield.svg)](https://madewithreactjs.com/p/peri/shield-link)
+


### PR DESCRIPTION
Currently this line reads as "You can find the translations files in this folder." on GitHub with no link! Turns out the link is there but there's an extra set of parenthesis which breaks it.