### PR TITLE
#319:Feature/adding Marathi translation

### DIFF
--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -46,6 +46,7 @@ const locales = new Map([
   ["kn", kn],
   ["mm", th],
   ["bn", bn],
+  ["mr", hi],
 ]);
 
 const defaultLocale = "en";

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -25,6 +25,7 @@ import ml from "./translations/ml";
 import kn from "./translations/kn";
 import mm from "./translations/mm";
 import bn from "./translations/bn";
+import mr from "./translations/mr";
 
 import { storage } from "../data/Storage";
 import { configuration } from "../data/AppConfiguration";
@@ -55,6 +56,7 @@ export const supportedLanguages = new Map<string, string>([
         ["ta", "தமிழ் (β)"],
         ["tl", "tagalog (β)"],
         ["vi", "tiếng Việt (β)"],
+        ["mr", "मराठी (β)"],
       ] as const)
     : []),
 ]);
@@ -137,6 +139,9 @@ export async function init() {
         bn: {
           translation: bn,
         },
+        mr: {
+          translation: mr,
+        },
       },
       lng: (await storage.getUnsafe.language()) || navigator.language,
       fallbackLng: {
@@ -162,6 +167,7 @@ export async function init() {
         kn: ["kn"],
         mm: ["mm"],
         bn: ["bn"],
+        mr: ["mr"],
         default: [defaultLanguageCode],
       },
     } satisfies InitOptions);

--- a/src/utils/translations/mr.ts
+++ b/src/utils/translations/mr.ts
@@ -1,41 +1,39 @@
 const mr = {
   Home: "मुख पृष्ठ",
-  "Period in": "पाळी येण्यास", 
+  "Period in": "पाळी येण्यास",
   "no info": "माहिती उपलब्ध नाही",
-  Period: "पाळी", 
+  Period: "पाळी",
   today: "आज",
-  Delay: "पाळी उशीर", 
-  Days: "दिवस", 
+  Delay: "पाळी उशीर",
+  Days: "दिवस",
   "Current cycle day": "सध्याचा सायकल दिवस",
 
-  day: "पाळी – {{count}}वा दिवस", 
+  day: "पाळी – {{count}}वा दिवस",
   Ovulation: "अंडोत्सर्जन",
-  possible: "संभाव्य", 
-  finished: "पूर्ण झाले", 
-  tomorrow: "उद्या", 
-  in: "मध्ये", 
-  "chance of getting pregnant": "गर्भधारणेची शक्यता", 
+  possible: "संभाव्य",
+  finished: "पूर्ण झाले",
+  tomorrow: "उद्या",
+  in: "मध्ये",
+  "chance of getting pregnant": "गर्भधारणेची शक्यता",
   High: "जास्त",
   Low: "कमी",
   "Period today": "आज पाळी",
   edit: "संपादन",
   save: "जतन करा",
-  "Period is": "पाळी आहे", 
+  "Period is": "पाळी आहे",
   "possible today": "आज शक्यता आहे",
 
   Details: "तपशील",
-  "Period length": "पाळीचा कालावधी", 
-  "Cycle length": "सायकलचा कालावधी", 
+  "Period length": "पाळीचा कालावधी",
+  "Cycle length": "सायकलचा कालावधी",
   "You haven't marked any periods yet": "तुम्ही अजून पाळी नोंदवलेली नाही",
 
-  
-  mark: "नोंद करा", 
+  mark: "नोंद करा",
   cancel: "रद्द करा",
 
-  
   "Welcome to Peri": "पेरी मध्ये तुमचे स्वागत आहे",
-  "Mark the days of your": "तुमच्या पाळीचे दिवस नोंद करा", 
-  "last period": "शेवटची पाळी", 
+  "Mark the days of your": "तुमच्या पाळीचे दिवस नोंद करा",
+  "last period": "शेवटची पाळी",
   Continue: "पुढे चला",
   "Forecast will not be generated.": "अंदाज तयार केला जाणार नाही.",
   or: "किंवा",
@@ -44,14 +42,16 @@ const mr = {
   "is current phase of cycle": "हा सायकलचा सध्याचा टप्पा आहे", // eg. Menstrual phase is current phase of cycle"
 
   "Menstrual phase": "मासिक पाळीचा टप्पा",
-  "This cycle is accompanied by low hormone levels.": "या टप्प्यात हार्मोन्सची पातळी कमी असते.",
+  "This cycle is accompanied by low hormone levels.":
+    "या टप्प्यात हार्मोन्सची पातळी कमी असते.",
   "lack of energy and strength": "ऊर्जा आणि ताकद कमी वाटणे",
   pain: "वेदना",
   "weakness and irritability": "अशक्तपणा आणि चिडचिड",
   "increased appetite": "भूक वाढणे",
 
   "Follicular phase": "फॉलिक्युलर टप्पा",
-  "The level of estrogen in this phase rises and reaches a maximum level.": "या टप्प्यात इस्ट्रोजेन हार्मोनची पातळी वाढून कमाल स्तरावर पोहोचते.",
+  "The level of estrogen in this phase rises and reaches a maximum level.":
+    "या टप्प्यात इस्ट्रोजेन हार्मोनची पातळी वाढून कमाल स्तरावर पोहोचते.",
   "strength and vigor appear": "ताकद आणि उत्साह जाणवतो",
   "endurance increases": "सहनशक्ती वाढते",
   "new ideas and plans appear": "नवीन कल्पना आणि योजना सुचतात",
@@ -76,31 +76,31 @@ const mr = {
   "diarrhea or constipation": "जुलाब किंवा बद्धकोष्ठता",
   "irritability and depressed mood": "चिडचिड आणि उदास मनःस्थिती",
 
-Preferences: "प्राधान्ये",
-Edit: "संपादन",
-Language: "भाषा",
-Theme: "थीम",
-"Import config": "सेटिंग आयात करा",
-"Export config": "सेटिंग निर्यात करा",
-"Configuration has been imported": "सेटिंग यशस्वीरित्या आयात झाली",
-"Download latest version": "नवीनतम आवृत्ती डाउनलोड करा",
-"We are on GitHub": "आम्ही GitHub वर आहोत",
-"Stored cycles count": "जतन केलेल्या सायकल्सची संख्या",
+  Preferences: "प्राधान्ये",
+  Edit: "संपादन",
+  Language: "भाषा",
+  Theme: "थीम",
+  "Import config": "सेटिंग आयात करा",
+  "Export config": "सेटिंग निर्यात करा",
+  "Configuration has been imported": "सेटिंग यशस्वीरित्या आयात झाली",
+  "Download latest version": "नवीनतम आवृत्ती डाउनलोड करा",
+  "We are on GitHub": "आम्ही GitHub वर आहोत",
+  "Stored cycles count": "जतन केलेल्या सायकल्सची संख्या",
 
-"This is just a demo": "हे फक्त डेमो आहे",
-"You can download the application ": "तुम्ही अ‍ॅप डाउनलोड करू शकता ",
-here: "इथे",
+  "This is just a demo": "हे फक्त डेमो आहे",
+  "You can download the application ": "तुम्ही अ‍ॅप डाउनलोड करू शकता ",
+  here: "इथे",
 
-Notifications: "सूचना",
-"Period is coming soon": "पाळी लवकरच येणार आहे",
-"Your period may start tomorrow": "तुमची पाळी उद्या येऊ शकते",
-"Your period may start today": "तुमची पाळी आज येऊ शकते",
+  Notifications: "सूचना",
+  "Period is coming soon": "पाळी लवकरच येणार आहे",
+  "Your period may start tomorrow": "तुमची पाळी उद्या येऊ शकते",
+  "Your period may start today": "तुमची पाळी आज येऊ शकते",
 
-"Confirm selection": "निवड निश्चित करा",
-"Are you sure you want to change the number of stored cycles?":
-  "जतन केलेल्या सायकल्सची संख्या बदलायची आहे का?",
-"Reducing the number will permanently remove some cycles.":
-  "संख्या कमी केल्यास काही सायकल्स कायमस्वरूपी हटवल्या जातील.",
+  "Confirm selection": "निवड निश्चित करा",
+  "Are you sure you want to change the number of stored cycles?":
+    "जतन केलेल्या सायकल्सची संख्या बदलायची आहे का?",
+  "Reducing the number will permanently remove some cycles.":
+    "संख्या कमी केल्यास काही सायकल्स कायमस्वरूपी हटवल्या जातील.",
 };
 
 export default mr;

--- a/src/utils/translations/mr.ts
+++ b/src/utils/translations/mr.ts
@@ -1,0 +1,106 @@
+const mr = {
+  Home: "मुख पृष्ठ",
+  "Period in": "पाळी येण्यास", 
+  "no info": "माहिती उपलब्ध नाही",
+  Period: "पाळी", 
+  today: "आज",
+  Delay: "पाळी उशीर", 
+  Days: "दिवस", 
+  "Current cycle day": "सध्याचा सायकल दिवस",
+
+  day: "पाळी – {{count}}वा दिवस", 
+  Ovulation: "अंडोत्सर्जन",
+  possible: "संभाव्य", 
+  finished: "पूर्ण झाले", 
+  tomorrow: "उद्या", 
+  in: "मध्ये", 
+  "chance of getting pregnant": "गर्भधारणेची शक्यता", 
+  High: "जास्त",
+  Low: "कमी",
+  "Period today": "आज पाळी",
+  edit: "संपादन",
+  save: "जतन करा",
+  "Period is": "पाळी आहे", 
+  "possible today": "आज शक्यता आहे",
+
+  Details: "तपशील",
+  "Period length": "पाळीचा कालावधी", 
+  "Cycle length": "सायकलचा कालावधी", 
+  "You haven't marked any periods yet": "तुम्ही अजून पाळी नोंदवलेली नाही",
+
+  
+  mark: "नोंद करा", 
+  cancel: "रद्द करा",
+
+  
+  "Welcome to Peri": "पेरी मध्ये तुमचे स्वागत आहे",
+  "Mark the days of your": "तुमच्या पाळीचे दिवस नोंद करा", 
+  "last period": "शेवटची पाळी", 
+  Continue: "पुढे चला",
+  "Forecast will not be generated.": "अंदाज तयार केला जाणार नाही.",
+  or: "किंवा",
+
+  "Frequent symptoms": "सामान्य लक्षणे",
+  "is current phase of cycle": "हा सायकलचा सध्याचा टप्पा आहे", // eg. Menstrual phase is current phase of cycle"
+
+  "Menstrual phase": "मासिक पाळीचा टप्पा",
+  "This cycle is accompanied by low hormone levels.": "या टप्प्यात हार्मोन्सची पातळी कमी असते.",
+  "lack of energy and strength": "ऊर्जा आणि ताकद कमी वाटणे",
+  pain: "वेदना",
+  "weakness and irritability": "अशक्तपणा आणि चिडचिड",
+  "increased appetite": "भूक वाढणे",
+
+  "Follicular phase": "फॉलिक्युलर टप्पा",
+  "The level of estrogen in this phase rises and reaches a maximum level.": "या टप्प्यात इस्ट्रोजेन हार्मोनची पातळी वाढून कमाल स्तरावर पोहोचते.",
+  "strength and vigor appear": "ताकद आणि उत्साह जाणवतो",
+  "endurance increases": "सहनशक्ती वाढते",
+  "new ideas and plans appear": "नवीन कल्पना आणि योजना सुचतात",
+  "libido increases": "लैंगिक इच्छा वाढते",
+
+  "Ovulation phase": "अंडोत्सर्जन टप्पा",
+  "Once estrogen levels peak, they trigger the release of two important ovulation hormones, follicle-stimulating hormone and luteinizing hormone.":
+    "इस्ट्रोजेनची पातळी वाढल्यानंतर FSH आणि LH हे महत्त्वाचे हार्मोन्स स्रवतात.",
+  "increased sexual desire": "लैंगिक इच्छा वाढते",
+  "optimistic mood": "सकारात्मक मनःस्थिती",
+  "mild fever": "हलका ताप",
+  "lower abdominal pain": "ओटीपोटात वेदना",
+  "chest discomfort and bloating": "छातीत जडपणा आणि पोट फुगणे",
+  "characteristic secretions ": "वैशिष्ट्यपूर्ण स्त्राव",
+
+  "Luteal phase": "ल्युटियल टप्पा",
+  "Levels of the hormones estrogen and progesterone first rise and then drop sharply just before a period. Progesterone reaches its peak in the luteal phase.":
+    "या टप्प्यात इस्ट्रोजेन आणि प्रोजेस्टेरॉन आधी वाढतात व पाळीच्या आधी कमी होतात.",
+  "breast tenderness": "स्तनात कोमलता",
+  puffiness: "सूज",
+  "acne and skin rashes": "मुरुम आणि त्वचेवर पुरळ",
+  "diarrhea or constipation": "जुलाब किंवा बद्धकोष्ठता",
+  "irritability and depressed mood": "चिडचिड आणि उदास मनःस्थिती",
+
+Preferences: "प्राधान्ये",
+Edit: "संपादन",
+Language: "भाषा",
+Theme: "थीम",
+"Import config": "सेटिंग आयात करा",
+"Export config": "सेटिंग निर्यात करा",
+"Configuration has been imported": "सेटिंग यशस्वीरित्या आयात झाली",
+"Download latest version": "नवीनतम आवृत्ती डाउनलोड करा",
+"We are on GitHub": "आम्ही GitHub वर आहोत",
+"Stored cycles count": "जतन केलेल्या सायकल्सची संख्या",
+
+"This is just a demo": "हे फक्त डेमो आहे",
+"You can download the application ": "तुम्ही अ‍ॅप डाउनलोड करू शकता ",
+here: "इथे",
+
+Notifications: "सूचना",
+"Period is coming soon": "पाळी लवकरच येणार आहे",
+"Your period may start tomorrow": "तुमची पाळी उद्या येऊ शकते",
+"Your period may start today": "तुमची पाळी आज येऊ शकते",
+
+"Confirm selection": "निवड निश्चित करा",
+"Are you sure you want to change the number of stored cycles?":
+  "जतन केलेल्या सायकल्सची संख्या बदलायची आहे का?",
+"Reducing the number will permanently remove some cycles.":
+  "संख्या कमी केल्यास काही सायकल्स कायमस्वरूपी हटवल्या जातील.",
+};
+
+export default mr;


### PR DESCRIPTION
This PR adds Marathi translations for the app.

Marathi (मराठी) is a language spoken in Maharashtra, India.
Adds translation for all existing UI text including:
Home screen
Period tracking labels
Phases info
Menstrual health info
Since date-fns does not support Marathi locale, the Hindi locale is used as fallback for date formatting.

This will allow Marathi-speaking users to use the app in their native language.